### PR TITLE
Add yah-kg knowledge graph contract crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1480,3 +1480,13 @@ name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "yah-kg"
+version = "0.5.4"
+dependencies = [
+ "blake3",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "rshack",
     "rs-hack-mcp",
     "rs-hack-arch",
+    "yah-kg",
 ]
 resolver = "2"
 
@@ -21,6 +22,7 @@ core = { description = "AST parsing, node types, and edit operations", allowed_d
 cli = { description = "Clap-based CLI frontend", allowed_dependencies = ["core"] }
 mcp = { description = "MCP server - JSON-RPC bridge to CLI", allowed_dependencies = ["core"] }
 arch = { description = "Architecture knowledge graph from source annotations", allowed_dependencies = ["core"] }
+kg = { description = "Multi-language structural knowledge graph contract (yah daemon)", allowed_dependencies = [] }
 
 [workspace.metadata.arch.roles]
 parser = "Parses Rust source into syn AST"

--- a/yah-kg/Cargo.toml
+++ b/yah-kg/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "yah-kg"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Knowledge-graph contract types and indexer trait for the yah daemon"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+thiserror = "1.0"
+blake3 = "1.5"

--- a/yah-kg/src/edge.rs
+++ b/yah-kg/src/edge.rs
@@ -1,0 +1,137 @@
+//! @arch:layer(kg)
+//! @arch:role(schema)
+//!
+//! Edge taxonomy. Same hybrid shape as `NodeKind`: a small core of
+//! universal edges plus per-language extras for concepts that don't
+//! generalize (Rust impls/macros, TS extends/decorators, JSON/YAML
+//! refs, Koda).
+//!
+//! Edge identity is a content hash of (from, to, kind) so duplicate
+//! emits dedupe naturally.
+
+use crate::ids::NodeId;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct EdgeId(pub [u8; 16]);
+
+impl EdgeId {
+    pub fn compute(from: NodeId, to: NodeId, kind: &EdgeKind) -> Self {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(&from.0);
+        hasher.update(&to.0);
+        let kind_tag = serde_json::to_vec(kind).unwrap_or_default();
+        hasher.update(&kind_tag);
+        let mut bytes = [0u8; 16];
+        bytes.copy_from_slice(&hasher.finalize().as_bytes()[..16]);
+        EdgeId(bytes)
+    }
+}
+
+impl std::fmt::Debug for EdgeId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut s = String::with_capacity(32);
+        for byte in self.0 {
+            use std::fmt::Write;
+            let _ = write!(s, "{:02x}", byte);
+        }
+        write!(f, "EdgeId({})", s)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(tag = "edge", content = "extra", rename_all = "snake_case")]
+pub enum EdgeKind {
+    // ---------- Universal structural ----------
+    /// dir → file, file → module, module → type/fn, type → field.
+    Contains,
+    /// type → method, trait → method, impl → method.
+    Defines,
+    /// Rust `use`, TS `import`.
+    Imports,
+    /// Rust `pub use`, TS `export ... from`.
+    ReExports,
+    /// fn/method → fn/method invocation site.
+    Calls,
+    /// type used as parameter, return type, or field type.
+    References,
+    /// Materialized convenience edge: type → trait it implements.
+    /// Derived from `ImplFor` + `ImplOfTrait`; emit for query speed.
+    Implements,
+
+    // ---------- Rust-specific ----------
+    /// Impl → Type: the type the impl block applies to.
+    ImplFor,
+    /// Impl → Trait: the trait being implemented (absent for inherent impls).
+    ImplOfTrait,
+    /// Site → MacroDecl: function-like macro invocation.
+    MacroInvokes,
+    /// Type → MacroDecl: `#[derive(Foo)]`.
+    DerivedBy,
+    /// Item → MacroDecl: attribute macro applied.
+    AttributedBy,
+    /// Generic param → Trait: trait bound.
+    Bounds,
+    /// Synthesized item → MacroDecl that produced it. Reserved for v2
+    /// when the indexer integrates `cargo expand`-style provenance.
+    GeneratedBy,
+
+    // ---------- TS-specific ----------
+    /// Class extends class, interface extends interface.
+    Extends,
+    /// Item → Decorator.
+    DecoratedBy,
+
+    // ---------- Doc-specific (JSON / YAML) ----------
+    /// `$ref`, YAML `*alias`, kustomize base, helm values lookup.
+    RefersTo,
+    /// Document → schema it conforms to.
+    ConformsTo,
+
+    // ---------- Koda extension slot ----------
+    Koda(KodaEdge),
+}
+
+/// Koda-specific edge kinds. Placeholder until the DSL grammar lands.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(tag = "koda_edge", rename_all = "snake_case")]
+pub enum KodaEdge {
+    Placeholder,
+}
+
+/// Shape returned by subgraph and neighbor queries. Carries the edge
+/// id (so the UI can request removal / inspect annotations) and any
+/// annotation overlay refs from `rs-hack-arch`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EdgeOut {
+    pub id: EdgeId,
+    pub from: NodeId,
+    pub to: NodeId,
+    pub kind: EdgeKind,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub annotations: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kind::Lang;
+
+    #[test]
+    fn edge_id_dedupes_same_triple() {
+        let a = NodeId::compute(Lang::Rust, "A", "a.rs");
+        let b = NodeId::compute(Lang::Rust, "B", "b.rs");
+        let e1 = EdgeId::compute(a, b, &EdgeKind::Calls);
+        let e2 = EdgeId::compute(a, b, &EdgeKind::Calls);
+        assert_eq!(e1, e2);
+    }
+
+    #[test]
+    fn edge_id_distinguishes_kind() {
+        let a = NodeId::compute(Lang::Rust, "A", "a.rs");
+        let b = NodeId::compute(Lang::Rust, "B", "b.rs");
+        let e1 = EdgeId::compute(a, b, &EdgeKind::Calls);
+        let e2 = EdgeId::compute(a, b, &EdgeKind::Imports);
+        assert_ne!(e1, e2);
+    }
+}

--- a/yah-kg/src/event.rs
+++ b/yah-kg/src/event.rs
@@ -1,0 +1,95 @@
+//! @arch:layer(kg)
+//! @arch:role(protocol)
+//!
+//! `ArchEvent` — the push channel from the daemon to subscribers.
+//!
+//! Two consumers care about this stream: the Tauri shell (which uses
+//! events to incrementally update ArchView, the Board, and Agent
+//! status overlays) and any pi-mono agent loop wanting structural
+//! awareness of its own edits.
+//!
+//! `AgentTouch` is the integration point that lets the UI candle-pulse
+//! the nodes a running agent has touched. The daemon resolves the
+//! agent's tool-call paths against its `(file, line) → NodeId` index
+//! server-side so the browser never does path resolution.
+
+use crate::edge::{EdgeId, EdgeOut};
+use crate::ids::{NodeId, NodeRef};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "event", rename_all = "snake_case")]
+pub enum ArchEvent {
+    IndexStarted {
+        reason: IndexReason,
+        scope: IndexScope,
+    },
+    IndexFinished {
+        duration_ms: u64,
+        nodes_added: u32,
+        nodes_changed: u32,
+        nodes_removed: u32,
+        edges_added: u32,
+        edges_removed: u32,
+    },
+    NodeAdded {
+        node: NodeRef,
+    },
+    NodeChanged {
+        id: NodeId,
+        fields: Vec<ChangedField>,
+    },
+    NodeRemoved {
+        id: NodeId,
+    },
+    EdgeAdded {
+        edge: EdgeOut,
+    },
+    EdgeRemoved {
+        id: EdgeId,
+    },
+    /// Pi-mono agent touched these nodes via a tool call. The daemon
+    /// is responsible for resolving the agent's `path:line` payloads
+    /// to node ids; subscribers just react.
+    AgentTouch {
+        ids: Vec<NodeId>,
+        tool: String,
+        relay: String,
+        ts: u64,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IndexReason {
+    /// Daemon cold-start (re-hydrating from snapshot or full reindex).
+    Boot,
+    /// File-watcher noticed a change on disk.
+    FileWatch,
+    /// Operator explicitly requested via `arch.reindex`.
+    Manual,
+    /// Pi-mono agent edited a file mid-session.
+    AgentEdit,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "scope", rename_all = "snake_case")]
+pub enum IndexScope {
+    All,
+    Files { paths: Vec<String> },
+    Subtree { root: String },
+}
+
+/// Which fields of a node changed in a `NodeChanged` event. Lets the UI
+/// avoid full re-renders when only metadata moved.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChangedField {
+    Span,
+    Label,
+    Qualified,
+    File,
+    Doc,
+    Properties,
+    Annotations,
+}

--- a/yah-kg/src/ids.rs
+++ b/yah-kg/src/ids.rs
@@ -1,0 +1,199 @@
+//! @arch:layer(kg)
+//! @arch:role(schema)
+//!
+//! Identity types: `NodeId`, `Span`, `NodeRef`, `NodeFull`.
+//!
+//! `NodeId` is a 16-byte blake3-truncated content hash. It is opaque to
+//! consumers and stable across rebuilds as long as the (lang, qualified
+//! name, file) triple is unchanged. A rename invalidates the id, which is
+//! the correct behaviour: a rename is a remove+add at the graph level.
+
+use crate::kind::{Lang, NodeKind};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::collections::BTreeMap;
+use std::fmt;
+
+/// Opaque, content-addressed node identifier (16 bytes of blake3).
+///
+/// Serializes to a lowercase 32-char hex string for JSON friendliness.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct NodeId(pub [u8; 16]);
+
+impl NodeId {
+    /// Compute a NodeId from the canonical identity triple.
+    ///
+    /// `qualified` is the language-aware fully qualified name (e.g.
+    /// `voice_allocator::mixer::AudioMixer` for Rust, `src/foo.ts::Bar` for
+    /// TS). `file` is the rig-relative path. `lang` discriminates so that a
+    /// Rust `Foo` and a TS `Foo` at the same path never collide.
+    pub fn compute(lang: Lang, qualified: &str, file: &str) -> Self {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(&[lang as u8]);
+        hasher.update(qualified.as_bytes());
+        hasher.update(&[0]);
+        hasher.update(file.as_bytes());
+        let hash = hasher.finalize();
+        let mut bytes = [0u8; 16];
+        bytes.copy_from_slice(&hash.as_bytes()[..16]);
+        NodeId(bytes)
+    }
+
+    pub fn to_hex(self) -> String {
+        let mut s = String::with_capacity(32);
+        for byte in self.0 {
+            use std::fmt::Write;
+            let _ = write!(s, "{:02x}", byte);
+        }
+        s
+    }
+
+    pub fn from_hex(s: &str) -> Result<Self, IdParseError> {
+        if s.len() != 32 {
+            return Err(IdParseError::Length(s.len()));
+        }
+        let mut bytes = [0u8; 16];
+        for (i, byte) in bytes.iter_mut().enumerate() {
+            let hi = hex_nibble(s.as_bytes()[i * 2])?;
+            let lo = hex_nibble(s.as_bytes()[i * 2 + 1])?;
+            *byte = (hi << 4) | lo;
+        }
+        Ok(NodeId(bytes))
+    }
+}
+
+fn hex_nibble(b: u8) -> Result<u8, IdParseError> {
+    match b {
+        b'0'..=b'9' => Ok(b - b'0'),
+        b'a'..=b'f' => Ok(b - b'a' + 10),
+        b'A'..=b'F' => Ok(b - b'A' + 10),
+        _ => Err(IdParseError::NonHex(b as char)),
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum IdParseError {
+    #[error("expected 32 hex chars, got {0}")]
+    Length(usize),
+    #[error("non-hex character {0:?}")]
+    NonHex(char),
+}
+
+impl fmt::Debug for NodeId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "NodeId({})", self.to_hex())
+    }
+}
+
+impl fmt::Display for NodeId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.to_hex())
+    }
+}
+
+impl Serialize for NodeId {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.to_hex())
+    }
+}
+
+impl<'de> Deserialize<'de> for NodeId {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        NodeId::from_hex(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Source span within a file. Lines and columns are 1-based to match
+/// the conventions of `proc_macro2::LineColumn` and most editors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Span {
+    pub start_line: u32,
+    pub start_col: u32,
+    pub end_line: u32,
+    pub end_col: u32,
+}
+
+impl Span {
+    pub fn point(line: u32, col: u32) -> Self {
+        Span { start_line: line, start_col: col, end_line: line, end_col: col }
+    }
+
+    pub fn contains_line(&self, line: u32) -> bool {
+        line >= self.start_line && line <= self.end_line
+    }
+}
+
+/// The light-weight node shape returned by subgraph and neighbor queries.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NodeRef {
+    pub id: NodeId,
+    pub lang: Lang,
+    pub kind: NodeKind,
+    /// Short display name, e.g. `AudioMixer`.
+    pub label: String,
+    /// Language-aware fully qualified name, e.g.
+    /// `voice_allocator::mixer::AudioMixer`.
+    pub qualified: String,
+    /// Rig-relative path.
+    pub file: String,
+    pub span: Span,
+    /// True when this node was synthesized by macro expansion or a
+    /// codegen pass rather than appearing literally in source.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub synthetic: bool,
+}
+
+fn is_false(b: &bool) -> bool {
+    !*b
+}
+
+/// The full node shape returned by `arch.node` — `NodeRef` plus the
+/// indexer-provided property bag and any annotation overlay refs.
+///
+/// `properties` is a free-form string map per node kind (e.g. Rust
+/// `Trait` may carry `auto = "true"`, TS `Decorator` carries
+/// `target_kind = "method"`). Keep keys snake_case.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NodeFull {
+    #[serde(flatten)]
+    pub node: NodeRef,
+    /// Doc-comment text attached to the item, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub doc: Option<String>,
+    /// Free-form per-kind metadata.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub properties: BTreeMap<String, String>,
+    /// Annotation overlay references (resolved by `rs-hack-arch`).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub annotations: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn node_id_roundtrips_hex() {
+        let id = NodeId::compute(Lang::Rust, "foo::bar::Baz", "src/foo.rs");
+        let hex = id.to_hex();
+        assert_eq!(hex.len(), 32);
+        let parsed = NodeId::from_hex(&hex).unwrap();
+        assert_eq!(parsed, id);
+    }
+
+    #[test]
+    fn node_id_is_lang_discriminated() {
+        let rust = NodeId::compute(Lang::Rust, "Foo", "src/foo.rs");
+        let ts = NodeId::compute(Lang::Ts, "Foo", "src/foo.rs");
+        assert_ne!(rust, ts);
+    }
+
+    #[test]
+    fn node_id_serializes_as_string() {
+        let id = NodeId::compute(Lang::Rust, "x", "y");
+        let json = serde_json::to_string(&id).unwrap();
+        assert!(json.starts_with('"') && json.ends_with('"'));
+        let back: NodeId = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, id);
+    }
+}

--- a/yah-kg/src/indexer.rs
+++ b/yah-kg/src/indexer.rs
@@ -1,0 +1,79 @@
+//! @arch:layer(kg)
+//! @arch:role(extract)
+//!
+//! `LanguageIndexer` is the single extension point per supported language.
+//! The daemon dispatches files to indexers based on `extensions()`.
+//!
+//! Indexers are pure: they read source text and push `NodeRef`/`EdgeOut`
+//! values into an `IndexSink`. They do not own storage, do not own the
+//! petgraph, and do not perform I/O. This keeps them trivially testable
+//! and lets the daemon batch sink writes any way it likes (in-memory
+//! petgraph, snapshot file, RPC fan-out).
+
+use crate::edge::EdgeOut;
+use crate::ids::{NodeId, NodeRef};
+use crate::kind::Lang;
+use std::path::Path;
+
+/// One language's extractor. Object-safe; the daemon holds these as
+/// `Box<dyn LanguageIndexer>` and dispatches by file extension.
+pub trait LanguageIndexer: Send + Sync {
+    fn lang(&self) -> Lang;
+
+    /// File extensions this indexer claims, lowercase, without the dot.
+    /// First-match wins in the daemon's dispatcher, so order indexers
+    /// from most-specific to most-generic at registration time.
+    fn extensions(&self) -> &[&'static str];
+
+    /// Parse one file and push every node and edge it produces into
+    /// `sink`. `path` is rig-relative; `src` is the file contents.
+    ///
+    /// Indexers should be deterministic: given the same `(path, src)`
+    /// they must emit the same nodes (with identical `NodeId`s, which
+    /// follows from using `NodeId::compute` with stable qualified names).
+    fn index_file(&self, path: &Path, src: &str, sink: &mut dyn IndexSink) -> Result<(), IndexError>;
+}
+
+/// Sink an indexer pushes structural facts into.
+///
+/// Implementations are owned by the daemon. A typical sink builds a
+/// `petgraph::DiGraph` and a `(file, line) → NodeId` lookup index in
+/// the same pass.
+pub trait IndexSink {
+    fn push_node(&mut self, node: NodeRef);
+    fn push_edge(&mut self, edge: EdgeOut);
+
+    /// Attach a free-form key/value to a previously pushed node.
+    /// Used by indexers to hang language-specific metadata
+    /// (`auto = "true"` on a Rust trait, `target_kind = "method"` on
+    /// a TS decorator) without bloating `NodeRef`.
+    fn push_property(&mut self, node: NodeId, key: &str, value: &str);
+
+    /// Attach a doc-comment block to a previously pushed node.
+    fn push_doc(&mut self, node: NodeId, doc: &str);
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum IndexError {
+    #[error("parse error in {path}: {message}")]
+    Parse { path: String, message: String },
+
+    #[error("io error: {0}")]
+    Io(String),
+
+    #[error("indexer is not yet implemented for this kind")]
+    Unimplemented,
+
+    /// Catch-all for indexer-specific failures. The daemon logs this
+    /// and skips the file rather than aborting indexing.
+    #[error("{0}")]
+    Other(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn _object_safe(_: &dyn LanguageIndexer) {}
+    fn _sink_object_safe(_: &mut dyn IndexSink) {}
+}

--- a/yah-kg/src/kind.rs
+++ b/yah-kg/src/kind.rs
@@ -1,0 +1,135 @@
+//! @arch:layer(kg)
+//! @arch:role(schema)
+//!
+//! Node kind taxonomy. A small `CommonKind` covers things that mean the
+//! same thing in every language; per-language enums (`RustKind`, `TsKind`,
+//! `DocKind`, `KodaKind`) carry the concepts that don't generalize.
+//!
+//! Cross-language consumers (UI, search) match on `CommonKind` and treat
+//! the language-specific variants as opaque hue/badge data. Language-aware
+//! consumers (the Rust trait/macro browser, the TS decorator inspector)
+//! match on the corresponding extra.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Lang {
+    Rust,
+    Ts,
+    Yaml,
+    Json,
+    Koda,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(tag = "lang", content = "kind", rename_all = "snake_case")]
+pub enum NodeKind {
+    Common(CommonKind),
+    Rust(RustKind),
+    Ts(TsKind),
+    Doc(DocKind),
+    Koda(KodaKind),
+}
+
+impl NodeKind {
+    /// True for nodes that act as containers in the structural graph
+    /// (directories, files, modules). Useful for graph-pruning queries.
+    pub fn is_container(&self) -> bool {
+        matches!(
+            self,
+            NodeKind::Common(CommonKind::Directory)
+                | NodeKind::Common(CommonKind::File)
+                | NodeKind::Common(CommonKind::Module)
+                | NodeKind::Common(CommonKind::Document)
+        )
+    }
+}
+
+/// Universal kinds — meaning is consistent across every supported language.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CommonKind {
+    /// Filesystem directory.
+    Directory,
+    /// Source file. The language is on the parent `NodeRef`.
+    File,
+    /// Logical grouping: Rust `mod`, TS namespace, etc.
+    Module,
+    /// Nominal type. The language extra distinguishes struct vs class
+    /// vs interface vs type-alias.
+    Type,
+    /// Free function.
+    Function,
+    /// Function bound to a type or impl.
+    Method,
+    /// Field of a struct/class/object schema.
+    Field,
+    /// Enum variant.
+    Variant,
+    /// Constant or static.
+    Constant,
+    /// Whole-file entity (used by JSON/YAML/Koda where the file IS
+    /// the addressable unit).
+    Document,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(tag = "rust_kind", rename_all = "snake_case")]
+pub enum RustKind {
+    /// `trait Foo { ... }`. Required and provided methods become
+    /// `Method` nodes linked by `Defines`.
+    Trait,
+    /// `impl Foo` or `impl Foo for Bar`. Modeled as a node so the graph
+    /// can answer "show every impl of Iterator". See `EdgeKind::ImplFor`
+    /// and `EdgeKind::ImplOfTrait`.
+    Impl,
+    AssocType,
+    AssocConst,
+    /// Macro declaration. Invocations are edges (see `EdgeKind`).
+    MacroDecl(MacroFlavor),
+    Lifetime,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MacroFlavor {
+    /// `macro_rules!`
+    Rules,
+    /// `#[proc_macro_derive(Foo)]`
+    ProcDerive,
+    /// `#[proc_macro_attribute]`
+    ProcAttr,
+    /// `#[proc_macro]`
+    ProcFn,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(tag = "ts_kind", rename_all = "snake_case")]
+pub enum TsKind {
+    Interface,
+    TypeAlias,
+    Enum,
+    Decorator,
+    JsxComponent,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(tag = "doc_kind", rename_all = "snake_case")]
+pub enum DocKind {
+    /// YAML `&anchor`.
+    Anchor,
+    /// Structural property of a JSON/YAML document (key path).
+    Property,
+    /// `$ref` target.
+    SchemaRef,
+}
+
+/// Koda DSL kinds — placeholder until the grammar lands.
+///
+/// Filled in by the `yah-kg-koda` indexer crate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(tag = "koda_kind", rename_all = "snake_case")]
+pub enum KodaKind {
+    Placeholder,
+}

--- a/yah-kg/src/lib.rs
+++ b/yah-kg/src/lib.rs
@@ -1,0 +1,28 @@
+//! @arch:layer(kg)
+//! @arch:role(schema)
+//!
+//! yah-kg — knowledge-graph contract crate.
+//!
+//! This crate defines the wire-shape of the yah architecture knowledge graph:
+//! identity (`NodeId`, `EdgeId`, `Span`), node/edge taxonomies (`NodeKind`,
+//! `EdgeKind`), the `LanguageIndexer` trait that per-language extractors
+//! implement, the RPC request/response shapes the daemon exposes under
+//! `arch.*`, and the `ArchEvent` stream consumed by the Tauri shell.
+//!
+//! Nothing here implements parsing, storage, or networking. It is a contract
+//! crate so the daemon, individual indexers, and the frontend bindings can
+//! depend on a stable type surface without dragging in `petgraph`, `syn`,
+//! `tree-sitter`, or transport machinery.
+
+pub mod edge;
+pub mod event;
+pub mod ids;
+pub mod indexer;
+pub mod kind;
+pub mod rpc;
+
+pub use edge::{EdgeId, EdgeKind, EdgeOut, KodaEdge};
+pub use event::{ArchEvent, ChangedField, IndexReason, IndexScope};
+pub use ids::{NodeFull, NodeId, NodeRef, Span};
+pub use indexer::{IndexError, IndexSink, LanguageIndexer};
+pub use kind::{CommonKind, DocKind, KodaKind, Lang, MacroFlavor, NodeKind, RustKind, TsKind};

--- a/yah-kg/src/rpc.rs
+++ b/yah-kg/src/rpc.rs
@@ -1,0 +1,285 @@
+//! @arch:layer(kg)
+//! @arch:role(protocol)
+//!
+//! RPC request/response shapes for the `arch.*` namespace exposed by
+//! the yah daemon. Transport-agnostic — the daemon may serve these
+//! over JSON-RPC stdio (Tauri local), JSON over HTTP (browser), or
+//! SSH-RPC (remote rig). All shapes here serialize to JSON.
+//!
+//! Method dispatch is by method name; the `RpcRequest`/`RpcResponse`
+//! enums are provided as a convenience for the daemon's router and
+//! for typed clients.
+
+use crate::edge::{EdgeKind, EdgeOut};
+use crate::ids::{NodeFull, NodeId, NodeRef};
+use crate::kind::{Lang, NodeKind};
+use serde::{Deserialize, Serialize};
+
+// ---------- arch.roots ----------
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RootsParams {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lang: Option<Lang>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<NodeKind>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RootsResult {
+    pub roots: Vec<NodeRef>,
+}
+
+// ---------- arch.subgraph ----------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SubgraphParams {
+    pub root: NodeId,
+    pub depth: u8,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub edges: Option<Vec<EdgeKind>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kinds: Option<Vec<NodeKind>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub langs: Option<Vec<Lang>>,
+    /// Hard cap on returned nodes. Daemon sets a default if absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub node_limit: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Subgraph {
+    pub root: NodeId,
+    pub nodes: Vec<NodeRef>,
+    pub edges: Vec<EdgeOut>,
+    /// True if the result was capped by `node_limit` or `depth`.
+    pub truncated: bool,
+}
+
+// ---------- arch.lookup ----------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LookupParams {
+    /// Rig-relative path.
+    pub file: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub col: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LookupResult {
+    /// Innermost-first: a method node before the type that contains it,
+    /// before the module, before the file.
+    pub ids: Vec<NodeId>,
+}
+
+// ---------- arch.node ----------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NodeParams {
+    pub id: NodeId,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NodeResult {
+    pub node: NodeFull,
+}
+
+// ---------- arch.neighbors ----------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Direction {
+    In,
+    Out,
+    Both,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NeighborsParams {
+    pub id: NodeId,
+    pub dir: Direction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub edges: Option<Vec<EdgeKind>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NeighborsResult {
+    pub edges: Vec<EdgeOut>,
+}
+
+// ---------- arch.path ----------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PathParams {
+    pub from: NodeId,
+    pub to: NodeId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub edges: Option<Vec<EdgeKind>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_len: Option<u8>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PathResult {
+    pub paths: Vec<Vec<EdgeOut>>,
+}
+
+// ---------- arch.search ----------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SearchParams {
+    pub q: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kinds: Option<Vec<NodeKind>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub langs: Option<Vec<Lang>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SearchHit {
+    pub id: NodeId,
+    pub label: String,
+    pub qualified: String,
+    pub score: f32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SearchResult {
+    pub hits: Vec<SearchHit>,
+}
+
+// ---------- arch.expand_macro (v2) ----------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExpandMacroParams {
+    pub id: NodeId,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExpandMacroResult {
+    /// Items synthesized by this macro (each `synthetic = true`).
+    pub generated: Vec<NodeRef>,
+}
+
+// ---------- arch.languages ----------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LanguagesResult {
+    pub langs: Vec<Lang>,
+}
+
+// ---------- arch.stats ----------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StatsResult {
+    pub node_count: u64,
+    pub edge_count: u64,
+    pub by_lang: std::collections::BTreeMap<String, u64>,
+    pub by_kind: std::collections::BTreeMap<String, u64>,
+    /// Wall-clock time of the most recent full or incremental index.
+    pub last_index_ms: Option<u64>,
+}
+
+// ---------- arch.reindex ----------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReindexParams {
+    /// Default `all` if absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<ReindexScope>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "scope", rename_all = "snake_case")]
+pub enum ReindexScope {
+    All,
+    File { path: String },
+    Subtree { root: String },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReindexResult {
+    pub job_id: String,
+}
+
+// ---------- Method registry ----------
+
+/// Canonical method names. Use these constants instead of stringly-typed
+/// dispatch in routers and clients to avoid drift.
+pub mod method {
+    pub const ROOTS: &str = "arch.roots";
+    pub const SUBGRAPH: &str = "arch.subgraph";
+    pub const LOOKUP: &str = "arch.lookup";
+    pub const NODE: &str = "arch.node";
+    pub const NEIGHBORS: &str = "arch.neighbors";
+    pub const PATH: &str = "arch.path";
+    pub const SEARCH: &str = "arch.search";
+    pub const EXPAND_MACRO: &str = "arch.expand_macro";
+    pub const LANGUAGES: &str = "arch.languages";
+    pub const STATS: &str = "arch.stats";
+    pub const REINDEX: &str = "arch.reindex";
+    pub const SUBSCRIBE: &str = "arch.subscribe";
+}
+
+/// Convenience tagged-union for routers that want to round-trip the
+/// whole RPC surface as one type. Optional — call sites can also
+/// dispatch on method strings directly and deserialize each param
+/// type independently.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "method", content = "params")]
+pub enum RpcRequest {
+    #[serde(rename = "arch.roots")]
+    Roots(RootsParams),
+    #[serde(rename = "arch.subgraph")]
+    Subgraph(SubgraphParams),
+    #[serde(rename = "arch.lookup")]
+    Lookup(LookupParams),
+    #[serde(rename = "arch.node")]
+    Node(NodeParams),
+    #[serde(rename = "arch.neighbors")]
+    Neighbors(NeighborsParams),
+    #[serde(rename = "arch.path")]
+    Path(PathParams),
+    #[serde(rename = "arch.search")]
+    Search(SearchParams),
+    #[serde(rename = "arch.expand_macro")]
+    ExpandMacro(ExpandMacroParams),
+    #[serde(rename = "arch.languages")]
+    Languages,
+    #[serde(rename = "arch.stats")]
+    Stats,
+    #[serde(rename = "arch.reindex")]
+    Reindex(ReindexParams),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "method", content = "result")]
+pub enum RpcResponse {
+    #[serde(rename = "arch.roots")]
+    Roots(RootsResult),
+    #[serde(rename = "arch.subgraph")]
+    Subgraph(Subgraph),
+    #[serde(rename = "arch.lookup")]
+    Lookup(LookupResult),
+    #[serde(rename = "arch.node")]
+    Node(NodeResult),
+    #[serde(rename = "arch.neighbors")]
+    Neighbors(NeighborsResult),
+    #[serde(rename = "arch.path")]
+    Path(PathResult),
+    #[serde(rename = "arch.search")]
+    Search(SearchResult),
+    #[serde(rename = "arch.expand_macro")]
+    ExpandMacro(ExpandMacroResult),
+    #[serde(rename = "arch.languages")]
+    Languages(LanguagesResult),
+    #[serde(rename = "arch.stats")]
+    Stats(StatsResult),
+    #[serde(rename = "arch.reindex")]
+    Reindex(ReindexResult),
+}


### PR DESCRIPTION
Introduce `yah-kg`, a new contract crate that defines the wire-shape and extension points for the yah architecture knowledge graph system.

## Summary

This PR adds a foundational crate that serves as the single source of truth for knowledge graph types, RPC protocols, and indexer interfaces. It enables the daemon, language-specific indexers, and frontend clients to share stable type definitions without circular dependencies or transport machinery.

## Key Changes

- **Identity types** (`ids.rs`): Defines `NodeId` (16-byte blake3 content hash), `Span` (source location), `NodeRef` (lightweight node), and `NodeFull` (complete node with metadata). NodeIds are language-discriminated and stable across rebuilds.

- **Node taxonomy** (`kind.rs`): Introduces `NodeKind` with a small universal `CommonKind` (directory, file, module, type, function, method, field, etc.) plus language-specific variants (`RustKind`, `TsKind`, `DocKind`, `KodaKind`) for concepts that don't generalize.

- **Edge taxonomy** (`edge.rs`): Defines `EdgeKind` with universal structural edges (Contains, Defines, Imports, Calls, References, Implements) and language-specific edges (Rust: ImplFor, MacroInvokes, DerivedBy; TypeScript: Extends, DecoratedBy; Doc: RefersTo, ConformsTo). Includes `EdgeId` content-addressed deduplication.

- **RPC protocol** (`rpc.rs`): Specifies request/response shapes for 11 `arch.*` methods (roots, subgraph, lookup, node, neighbors, path, search, expand_macro, languages, stats, reindex). Provides both individual param/result types and tagged-union enums for convenience routing.

- **Event stream** (`event.rs`): Defines `ArchEvent` for push notifications (index lifecycle, node/edge mutations, agent touches) consumed by the Tauri shell and agent loops.

- **Indexer trait** (`indexer.rs`): Establishes `LanguageIndexer` (object-safe, pure, file-to-nodes extraction) and `IndexSink` (push-based accumulation of nodes, edges, properties, docs). Indexers are deterministic and testable in isolation.

## Notable Details

- All types serialize to JSON for transport-agnostic RPC (JSON-RPC stdio, HTTP, SSH).
- `NodeId` uses blake3 truncation and serializes as lowercase hex strings.
- Edge identity deduplicates on (from, to, kind) triple.
- Indexers are pure functions; the daemon owns storage and graph mutations.
- Comprehensive test coverage for identity roundtrips and deduplication.
- Workspace integration: added to root `Cargo.toml` members list.

https://claude.ai/code/session_01Eg2y3Ux7oupjsHqsxYQecY