### PR TITLE
Add Rust indexer and in-memory knowledge graph store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1490,3 +1490,28 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "yah-kg-rust"
+version = "0.5.4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "yah-kg",
+ "yah-kg-store",
+]
+
+[[package]]
+name = "yah-kg-store"
+version = "0.5.4"
+dependencies = [
+ "petgraph",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 1.0.69",
+ "walkdir",
+ "yah-kg",
+ "yah-kg-rust",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,8 @@ members = [
     "rs-hack-mcp",
     "rs-hack-arch",
     "yah-kg",
+    "yah-kg-store",
+    "yah-kg-rust",
 ]
 resolver = "2"
 
@@ -23,6 +25,8 @@ cli = { description = "Clap-based CLI frontend", allowed_dependencies = ["core"]
 mcp = { description = "MCP server - JSON-RPC bridge to CLI", allowed_dependencies = ["core"] }
 arch = { description = "Architecture knowledge graph from source annotations", allowed_dependencies = ["core"] }
 kg = { description = "Multi-language structural knowledge graph contract (yah daemon)", allowed_dependencies = [] }
+kg_store = { description = "In-memory petgraph-backed store + walker behind the kg contract", allowed_dependencies = ["kg"] }
+kg_lang = { description = "Per-language indexer implementations (Rust, TS, JSON/YAML, Koda)", allowed_dependencies = ["kg"] }
 
 [workspace.metadata.arch.roles]
 parser = "Parses Rust source into syn AST"

--- a/yah-kg-rust/Cargo.toml
+++ b/yah-kg-rust/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "yah-kg-rust"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Rust language indexer for the yah knowledge graph"
+
+[dependencies]
+yah-kg = { path = "../yah-kg" }
+syn = { version = "2.0", features = ["full", "parsing", "extra-traits"] }
+proc-macro2 = { version = "1.0", features = ["span-locations"] }
+quote = "1.0"
+
+[dev-dependencies]
+yah-kg-store = { path = "../yah-kg-store" }

--- a/yah-kg-rust/src/indexer.rs
+++ b/yah-kg-rust/src/indexer.rs
@@ -1,0 +1,53 @@
+//! @arch:layer(kg)
+//! @arch:role(extract)
+//!
+//! `RustIndexer` — entry point implementing `LanguageIndexer`.
+
+use crate::visit::Walker;
+use std::path::Path;
+use yah_kg::indexer::{IndexError, IndexSink, LanguageIndexer};
+use yah_kg::kind::Lang;
+
+/// Default `LanguageIndexer` for `.rs` files.
+///
+/// Pure: holds no parser state, builds a fresh `Walker` per call so
+/// concurrent indexing is safe.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct RustIndexer;
+
+impl RustIndexer {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl LanguageIndexer for RustIndexer {
+    fn lang(&self) -> Lang {
+        Lang::Rust
+    }
+
+    fn extensions(&self) -> &[&'static str] {
+        &["rs"]
+    }
+
+    fn index_file(
+        &self,
+        path: &Path,
+        src: &str,
+        sink: &mut dyn IndexSink,
+    ) -> Result<(), IndexError> {
+        let path_str = path.to_string_lossy().replace('\\', "/");
+        let file = match syn::parse_file(src) {
+            Ok(f) => f,
+            Err(e) => {
+                return Err(IndexError::Parse {
+                    path: path_str,
+                    message: e.to_string(),
+                });
+            }
+        };
+        let mut walker = Walker::new(&path_str, sink);
+        walker.run(&file);
+        Ok(())
+    }
+}

--- a/yah-kg-rust/src/lib.rs
+++ b/yah-kg-rust/src/lib.rs
@@ -1,0 +1,26 @@
+//! @arch:layer(kg)
+//! @arch:role(extract)
+//!
+//! `yah-kg-rust` — `LanguageIndexer` for Rust source.
+//!
+//! Pass 1+2 within-file indexer. Given a `.rs` file, parses it with
+//! `syn::parse_file` and emits:
+//!
+//! * **Nodes:** `File`, `Module`, `Type` (struct/enum/union/type-alias),
+//!   `Field`, `Variant`, `Function`, `Method`, `Trait`, `Impl`,
+//!   `Constant`, `MacroDecl(Rules)`.
+//! * **Edges:** `Contains` (file→item, module→item, type→field/variant,
+//!   trait→method, impl→method), `Defines` (trait/impl→method),
+//!   `ImplFor` (impl→type), `ImplOfTrait` (impl→trait), `DerivedBy`
+//!   (type→derive macro), `AttributedBy` (item→attr macro).
+//!
+//! Cross-file resolution is **not** done here: `Imports`, `Calls`, and
+//! resolution of `super::Foo` / `crate::other::Foo` paths are Pass 3+
+//! daemon work. Within-file simple-name lookups (`impl Foo` where
+//! `struct Foo` lives in the same module) do resolve correctly because
+//! `NodeId::compute` is deterministic over `(lang, qualified, file)`.
+
+pub mod indexer;
+pub mod visit;
+
+pub use indexer::RustIndexer;

--- a/yah-kg-rust/src/visit.rs
+++ b/yah-kg-rust/src/visit.rs
@@ -1,0 +1,765 @@
+//! @arch:layer(kg)
+//! @arch:role(traverse)
+//!
+//! Syn AST walker. Pure within-file structural extraction.
+//!
+//! Walks the parsed `syn::File` once, maintaining a module-path stack
+//! and a parent-id stack so every emitted node gets a `Contains` edge
+//! from its enclosing item. Also emits Rust-specific edges:
+//! `ImplFor`, `ImplOfTrait`, `Defines`, plus derive/attribute info
+//! recorded as properties on the type (cross-file macro resolution is
+//! deferred to the daemon's Pass 3).
+
+use proc_macro2::LineColumn;
+use syn::spanned::Spanned;
+use yah_kg::edge::{EdgeId, EdgeKind, EdgeOut};
+use yah_kg::ids::{NodeId, NodeRef, Span};
+use yah_kg::indexer::IndexSink;
+use yah_kg::kind::{CommonKind, Lang, MacroFlavor, NodeKind, RustKind};
+
+const LANG: Lang = Lang::Rust;
+
+pub struct Walker<'a> {
+    file: String,
+    file_id: NodeId,
+    mod_path: Vec<String>,
+    parents: Vec<NodeId>,
+    sink: &'a mut dyn IndexSink,
+}
+
+impl<'a> Walker<'a> {
+    pub fn new(file: &str, sink: &'a mut dyn IndexSink) -> Self {
+        let file = file.replace('\\', "/");
+        let file_id = NodeId::compute(LANG, &file, &file);
+        Self {
+            file,
+            file_id,
+            mod_path: Vec::new(),
+            parents: Vec::new(),
+            sink,
+        }
+    }
+
+    pub fn run(&mut self, file: &syn::File) {
+        // Emit the File node so the daemon doesn't need to know whether
+        // the indexer or the walker is responsible. `upsert` dedupes.
+        let label = self
+            .file
+            .rsplit_once('/')
+            .map(|(_, n)| n.to_string())
+            .unwrap_or_else(|| self.file.clone());
+        let span = whole_file_span(file);
+        self.sink.push_node(NodeRef {
+            id: self.file_id,
+            lang: LANG,
+            kind: NodeKind::Common(CommonKind::File),
+            label,
+            qualified: self.file.clone(),
+            file: self.file.clone(),
+            span,
+            synthetic: false,
+        });
+        if let Some(d) = doc_of_attrs(&file.attrs) {
+            self.sink.push_doc(self.file_id, &d);
+        }
+        self.parents.push(self.file_id);
+        for item in &file.items {
+            self.walk_item(item);
+        }
+        self.parents.pop();
+    }
+
+    fn current_parent(&self) -> NodeId {
+        *self.parents.last().expect("parent stack invariant")
+    }
+
+    fn qualify(&self, name: &str) -> String {
+        if self.mod_path.is_empty() {
+            format!("{}::{}", self.file, name)
+        } else {
+            format!("{}::{}::{}", self.file, self.mod_path.join("::"), name)
+        }
+    }
+
+    fn make_id(&self, qualified: &str) -> NodeId {
+        NodeId::compute(LANG, qualified, &self.file)
+    }
+
+    fn emit_node(&mut self, node: NodeRef) {
+        self.sink.push_node(node);
+    }
+
+    fn emit_contains(&mut self, parent: NodeId, child: NodeId) {
+        self.sink.push_edge(EdgeOut {
+            id: EdgeId::compute(parent, child, &EdgeKind::Contains),
+            from: parent,
+            to: child,
+            kind: EdgeKind::Contains,
+            annotations: vec![],
+        });
+    }
+
+    fn emit_edge(&mut self, from: NodeId, to: NodeId, kind: EdgeKind) {
+        self.sink.push_edge(EdgeOut {
+            id: EdgeId::compute(from, to, &kind),
+            from,
+            to,
+            kind,
+            annotations: vec![],
+        });
+    }
+
+    fn walk_item(&mut self, item: &syn::Item) {
+        match item {
+            syn::Item::Mod(m) => self.walk_mod(m),
+            syn::Item::Struct(s) => self.walk_struct(s),
+            syn::Item::Enum(e) => self.walk_enum(e),
+            syn::Item::Union(u) => self.walk_union(u),
+            syn::Item::Type(t) => self.walk_type_alias(t),
+            syn::Item::Fn(f) => self.walk_fn(f),
+            syn::Item::Trait(t) => self.walk_trait(t),
+            syn::Item::Impl(i) => self.walk_impl(i),
+            syn::Item::Const(c) => self.walk_const(&c.ident, &c.attrs, c.span()),
+            syn::Item::Static(s) => self.walk_const(&s.ident, &s.attrs, s.span()),
+            syn::Item::Macro(m) => self.walk_macro_decl(m),
+            // Use, ExternCrate, ForeignMod, TraitAlias, Verbatim — Pass 3 work.
+            _ => {}
+        }
+    }
+
+    fn walk_mod(&mut self, m: &syn::ItemMod) {
+        let name = m.ident.to_string();
+        let qualified = self.qualify(&name);
+        let id = self.make_id(&qualified);
+        let parent = self.current_parent();
+        self.emit_node(NodeRef {
+            id,
+            lang: LANG,
+            kind: NodeKind::Common(CommonKind::Module),
+            label: name.clone(),
+            qualified,
+            file: self.file.clone(),
+            span: span_of(m),
+            synthetic: false,
+        });
+        self.emit_contains(parent, id);
+        if let Some(d) = doc_of_attrs(&m.attrs) {
+            self.sink.push_doc(id, &d);
+        }
+
+        if let Some((_, items)) = &m.content {
+            self.mod_path.push(name);
+            self.parents.push(id);
+            for item in items {
+                self.walk_item(item);
+            }
+            self.parents.pop();
+            self.mod_path.pop();
+        }
+    }
+
+    fn walk_struct(&mut self, s: &syn::ItemStruct) {
+        let name = s.ident.to_string();
+        let qualified = self.qualify(&name);
+        let id = self.make_id(&qualified);
+        let parent = self.current_parent();
+        self.emit_node(NodeRef {
+            id,
+            lang: LANG,
+            kind: NodeKind::Common(CommonKind::Type),
+            label: name.clone(),
+            qualified,
+            file: self.file.clone(),
+            span: span_of(s),
+            synthetic: false,
+        });
+        self.emit_contains(parent, id);
+        self.record_type_kind(id, "struct");
+        self.record_attrs(id, &s.attrs);
+        if let Some(d) = doc_of_attrs(&s.attrs) {
+            self.sink.push_doc(id, &d);
+        }
+
+        // Fields
+        let qualified_struct = self.qualify(&name);
+        for field in &s.fields {
+            self.walk_field(&qualified_struct, id, field);
+        }
+    }
+
+    fn walk_union(&mut self, u: &syn::ItemUnion) {
+        let name = u.ident.to_string();
+        let qualified = self.qualify(&name);
+        let id = self.make_id(&qualified);
+        let parent = self.current_parent();
+        self.emit_node(NodeRef {
+            id,
+            lang: LANG,
+            kind: NodeKind::Common(CommonKind::Type),
+            label: name.clone(),
+            qualified,
+            file: self.file.clone(),
+            span: span_of(u),
+            synthetic: false,
+        });
+        self.emit_contains(parent, id);
+        self.record_type_kind(id, "union");
+        self.record_attrs(id, &u.attrs);
+        if let Some(d) = doc_of_attrs(&u.attrs) {
+            self.sink.push_doc(id, &d);
+        }
+        let qualified_union = self.qualify(&name);
+        for field in &u.fields.named {
+            self.walk_field(&qualified_union, id, field);
+        }
+    }
+
+    fn walk_field(&mut self, parent_qualified: &str, parent_id: NodeId, field: &syn::Field) {
+        let Some(ident) = field.ident.as_ref() else {
+            // Tuple-struct fields: skip; they don't have stable ident-based ids.
+            return;
+        };
+        let name = ident.to_string();
+        let qualified = format!("{}::{}", parent_qualified, name);
+        let id = self.make_id(&qualified);
+        self.emit_node(NodeRef {
+            id,
+            lang: LANG,
+            kind: NodeKind::Common(CommonKind::Field),
+            label: name,
+            qualified,
+            file: self.file.clone(),
+            span: span_of(field),
+            synthetic: false,
+        });
+        self.emit_contains(parent_id, id);
+        if let Some(d) = doc_of_attrs(&field.attrs) {
+            self.sink.push_doc(id, &d);
+        }
+    }
+
+    fn walk_enum(&mut self, e: &syn::ItemEnum) {
+        let name = e.ident.to_string();
+        let qualified = self.qualify(&name);
+        let id = self.make_id(&qualified);
+        let parent = self.current_parent();
+        self.emit_node(NodeRef {
+            id,
+            lang: LANG,
+            kind: NodeKind::Common(CommonKind::Type),
+            label: name.clone(),
+            qualified,
+            file: self.file.clone(),
+            span: span_of(e),
+            synthetic: false,
+        });
+        self.emit_contains(parent, id);
+        self.record_type_kind(id, "enum");
+        self.record_attrs(id, &e.attrs);
+        if let Some(d) = doc_of_attrs(&e.attrs) {
+            self.sink.push_doc(id, &d);
+        }
+
+        let qualified_enum = self.qualify(&name);
+        for variant in &e.variants {
+            let v_name = variant.ident.to_string();
+            let v_qualified = format!("{}::{}", qualified_enum, v_name);
+            let v_id = self.make_id(&v_qualified);
+            self.emit_node(NodeRef {
+                id: v_id,
+                lang: LANG,
+                kind: NodeKind::Common(CommonKind::Variant),
+                label: v_name,
+                qualified: v_qualified,
+                file: self.file.clone(),
+                span: span_of(variant),
+                synthetic: false,
+            });
+            self.emit_contains(id, v_id);
+            if let Some(d) = doc_of_attrs(&variant.attrs) {
+                self.sink.push_doc(v_id, &d);
+            }
+        }
+    }
+
+    fn walk_type_alias(&mut self, t: &syn::ItemType) {
+        let name = t.ident.to_string();
+        let qualified = self.qualify(&name);
+        let id = self.make_id(&qualified);
+        let parent = self.current_parent();
+        self.emit_node(NodeRef {
+            id,
+            lang: LANG,
+            kind: NodeKind::Common(CommonKind::Type),
+            label: name,
+            qualified,
+            file: self.file.clone(),
+            span: span_of(t),
+            synthetic: false,
+        });
+        self.emit_contains(parent, id);
+        self.record_type_kind(id, "alias");
+        if let Some(d) = doc_of_attrs(&t.attrs) {
+            self.sink.push_doc(id, &d);
+        }
+    }
+
+    fn walk_fn(&mut self, f: &syn::ItemFn) {
+        let name = f.sig.ident.to_string();
+        let qualified = self.qualify(&name);
+        let id = self.make_id(&qualified);
+        let parent = self.current_parent();
+        self.emit_node(NodeRef {
+            id,
+            lang: LANG,
+            kind: NodeKind::Common(CommonKind::Function),
+            label: name,
+            qualified,
+            file: self.file.clone(),
+            span: span_of(f),
+            synthetic: false,
+        });
+        self.emit_contains(parent, id);
+        if f.sig.asyncness.is_some() {
+            self.sink.push_property(id, "async", "true");
+        }
+        if f.sig.unsafety.is_some() {
+            self.sink.push_property(id, "unsafe", "true");
+        }
+        if let Some(d) = doc_of_attrs(&f.attrs) {
+            self.sink.push_doc(id, &d);
+        }
+    }
+
+    fn walk_const(&mut self, ident: &syn::Ident, attrs: &[syn::Attribute], sp: proc_macro2::Span) {
+        let name = ident.to_string();
+        let qualified = self.qualify(&name);
+        let id = self.make_id(&qualified);
+        let parent = self.current_parent();
+        self.emit_node(NodeRef {
+            id,
+            lang: LANG,
+            kind: NodeKind::Common(CommonKind::Constant),
+            label: name,
+            qualified,
+            file: self.file.clone(),
+            span: span_from(sp),
+            synthetic: false,
+        });
+        self.emit_contains(parent, id);
+        if let Some(d) = doc_of_attrs(attrs) {
+            self.sink.push_doc(id, &d);
+        }
+    }
+
+    fn walk_trait(&mut self, t: &syn::ItemTrait) {
+        let name = t.ident.to_string();
+        let qualified = self.qualify(&name);
+        let id = self.make_id(&qualified);
+        let parent = self.current_parent();
+        self.emit_node(NodeRef {
+            id,
+            lang: LANG,
+            kind: NodeKind::Rust(RustKind::Trait),
+            label: name.clone(),
+            qualified,
+            file: self.file.clone(),
+            span: span_of(t),
+            synthetic: false,
+        });
+        self.emit_contains(parent, id);
+        if t.auto_token.is_some() {
+            self.sink.push_property(id, "auto", "true");
+        }
+        if t.unsafety.is_some() {
+            self.sink.push_property(id, "unsafe", "true");
+        }
+        if let Some(d) = doc_of_attrs(&t.attrs) {
+            self.sink.push_doc(id, &d);
+        }
+
+        let qualified_trait = self.qualify(&name);
+        for item in &t.items {
+            self.walk_trait_item(&qualified_trait, id, item);
+        }
+    }
+
+    fn walk_trait_item(
+        &mut self,
+        parent_qualified: &str,
+        parent_id: NodeId,
+        item: &syn::TraitItem,
+    ) {
+        match item {
+            syn::TraitItem::Fn(f) => {
+                let name = f.sig.ident.to_string();
+                let qualified = format!("{}::{}", parent_qualified, name);
+                let id = self.make_id(&qualified);
+                self.emit_node(NodeRef {
+                    id,
+                    lang: LANG,
+                    kind: NodeKind::Common(CommonKind::Method),
+                    label: name,
+                    qualified,
+                    file: self.file.clone(),
+                    span: span_of(f),
+                    synthetic: false,
+                });
+                self.emit_contains(parent_id, id);
+                self.emit_edge(parent_id, id, EdgeKind::Defines);
+                if f.default.is_none() {
+                    self.sink.push_property(id, "required", "true");
+                }
+                if let Some(d) = doc_of_attrs(&f.attrs) {
+                    self.sink.push_doc(id, &d);
+                }
+            }
+            syn::TraitItem::Type(t) => {
+                let name = t.ident.to_string();
+                let qualified = format!("{}::{}", parent_qualified, name);
+                let id = self.make_id(&qualified);
+                self.emit_node(NodeRef {
+                    id,
+                    lang: LANG,
+                    kind: NodeKind::Rust(RustKind::AssocType),
+                    label: name,
+                    qualified,
+                    file: self.file.clone(),
+                    span: span_of(t),
+                    synthetic: false,
+                });
+                self.emit_contains(parent_id, id);
+                self.emit_edge(parent_id, id, EdgeKind::Defines);
+            }
+            syn::TraitItem::Const(c) => {
+                let name = c.ident.to_string();
+                let qualified = format!("{}::{}", parent_qualified, name);
+                let id = self.make_id(&qualified);
+                self.emit_node(NodeRef {
+                    id,
+                    lang: LANG,
+                    kind: NodeKind::Rust(RustKind::AssocConst),
+                    label: name,
+                    qualified,
+                    file: self.file.clone(),
+                    span: span_of(c),
+                    synthetic: false,
+                });
+                self.emit_contains(parent_id, id);
+                self.emit_edge(parent_id, id, EdgeKind::Defines);
+            }
+            _ => {}
+        }
+    }
+
+    fn walk_impl(&mut self, i: &syn::ItemImpl) {
+        // Synthesize a stable name. Include the impl's start line so multiple
+        // impls of the same trait/type within one file get distinct ids.
+        let self_ty_name = path_of_type(&i.self_ty).unwrap_or_else(|| "?".to_string());
+        let trait_name = i
+            .trait_
+            .as_ref()
+            .map(|(_, p, _)| path_of_path(p))
+            .unwrap_or_default();
+        let line = i.span().start().line;
+        let synthetic_name = if trait_name.is_empty() {
+            format!("impl_for_{}@{}", self_ty_name, line)
+        } else {
+            format!("impl_{}_for_{}@{}", trait_name, self_ty_name, line)
+        };
+        let qualified = self.qualify(&synthetic_name);
+        let id = self.make_id(&qualified);
+        let parent = self.current_parent();
+        self.emit_node(NodeRef {
+            id,
+            lang: LANG,
+            kind: NodeKind::Rust(RustKind::Impl),
+            label: synthetic_name.clone(),
+            qualified,
+            file: self.file.clone(),
+            span: span_of(i),
+            synthetic: false,
+        });
+        self.emit_contains(parent, id);
+        if let Some(d) = doc_of_attrs(&i.attrs) {
+            self.sink.push_doc(id, &d);
+        }
+
+        // ImplFor: link impl → type (if resolvable to an in-scope simple ident).
+        if let Some(ty_ident) = simple_ident(&self_ty_name) {
+            let target_qualified = self.qualify(ty_ident);
+            let target_id = self.make_id(&target_qualified);
+            self.emit_edge(id, target_id, EdgeKind::ImplFor);
+            // Materialized convenience edge: type → trait.
+            if !trait_name.is_empty() {
+                if let Some(tr_ident) = simple_ident(&trait_name) {
+                    let trait_qualified = self.qualify(tr_ident);
+                    let trait_id = self.make_id(&trait_qualified);
+                    self.emit_edge(target_id, trait_id, EdgeKind::Implements);
+                }
+            }
+        }
+        // ImplOfTrait: link impl → trait (simple-ident only for v1).
+        if !trait_name.is_empty() {
+            if let Some(tr_ident) = simple_ident(&trait_name) {
+                let trait_qualified = self.qualify(tr_ident);
+                let trait_id = self.make_id(&trait_qualified);
+                self.emit_edge(id, trait_id, EdgeKind::ImplOfTrait);
+            }
+        }
+
+        // Walk impl items.
+        let qualified_impl = self.qualify(&synthetic_name);
+        for item in &i.items {
+            self.walk_impl_item(&qualified_impl, id, item);
+        }
+    }
+
+    fn walk_impl_item(
+        &mut self,
+        parent_qualified: &str,
+        parent_id: NodeId,
+        item: &syn::ImplItem,
+    ) {
+        match item {
+            syn::ImplItem::Fn(f) => {
+                let name = f.sig.ident.to_string();
+                let qualified = format!("{}::{}", parent_qualified, name);
+                let id = self.make_id(&qualified);
+                self.emit_node(NodeRef {
+                    id,
+                    lang: LANG,
+                    kind: NodeKind::Common(CommonKind::Method),
+                    label: name,
+                    qualified,
+                    file: self.file.clone(),
+                    span: span_of(f),
+                    synthetic: false,
+                });
+                self.emit_contains(parent_id, id);
+                self.emit_edge(parent_id, id, EdgeKind::Defines);
+                if f.sig.asyncness.is_some() {
+                    self.sink.push_property(id, "async", "true");
+                }
+                if f.sig.unsafety.is_some() {
+                    self.sink.push_property(id, "unsafe", "true");
+                }
+                if let Some(d) = doc_of_attrs(&f.attrs) {
+                    self.sink.push_doc(id, &d);
+                }
+            }
+            syn::ImplItem::Type(t) => {
+                let name = t.ident.to_string();
+                let qualified = format!("{}::{}", parent_qualified, name);
+                let id = self.make_id(&qualified);
+                self.emit_node(NodeRef {
+                    id,
+                    lang: LANG,
+                    kind: NodeKind::Rust(RustKind::AssocType),
+                    label: name,
+                    qualified,
+                    file: self.file.clone(),
+                    span: span_of(t),
+                    synthetic: false,
+                });
+                self.emit_contains(parent_id, id);
+                self.emit_edge(parent_id, id, EdgeKind::Defines);
+            }
+            syn::ImplItem::Const(c) => {
+                let name = c.ident.to_string();
+                let qualified = format!("{}::{}", parent_qualified, name);
+                let id = self.make_id(&qualified);
+                self.emit_node(NodeRef {
+                    id,
+                    lang: LANG,
+                    kind: NodeKind::Rust(RustKind::AssocConst),
+                    label: name,
+                    qualified,
+                    file: self.file.clone(),
+                    span: span_of(c),
+                    synthetic: false,
+                });
+                self.emit_contains(parent_id, id);
+                self.emit_edge(parent_id, id, EdgeKind::Defines);
+            }
+            _ => {}
+        }
+    }
+
+    fn walk_macro_decl(&mut self, m: &syn::ItemMacro) {
+        // `macro_rules! foo { ... }` is the only form syn surfaces here as
+        // Item::Macro with an ident. Top-level macro *invocations* (like
+        // `lazy_static!{}` at module scope) also parse as Item::Macro; we
+        // only treat it as a declaration when the path is `macro_rules`.
+        let path_str = path_of_path(&m.mac.path);
+        if path_str == "macro_rules" {
+            let Some(name) = m.ident.as_ref().map(|i| i.to_string()) else {
+                return;
+            };
+            let qualified = self.qualify(&name);
+            let id = self.make_id(&qualified);
+            let parent = self.current_parent();
+            self.emit_node(NodeRef {
+                id,
+                lang: LANG,
+                kind: NodeKind::Rust(RustKind::MacroDecl(MacroFlavor::Rules)),
+                label: name,
+                qualified,
+                file: self.file.clone(),
+                span: span_of(m),
+                synthetic: false,
+            });
+            self.emit_contains(parent, id);
+            if let Some(d) = doc_of_attrs(&m.attrs) {
+                self.sink.push_doc(id, &d);
+            }
+        }
+    }
+
+    fn record_type_kind(&mut self, id: NodeId, kind: &str) {
+        self.sink.push_property(id, "type_kind", kind);
+    }
+
+    fn record_attrs(&mut self, id: NodeId, attrs: &[syn::Attribute]) {
+        let mut derives: Vec<String> = Vec::new();
+        let mut macro_attrs: Vec<String> = Vec::new();
+        for attr in attrs {
+            if attr.path().is_ident("derive") {
+                let _ = attr.parse_nested_meta(|meta| {
+                    if let Some(ident) = meta.path.get_ident() {
+                        derives.push(ident.to_string());
+                    }
+                    Ok(())
+                });
+            } else if !is_doc_attr(attr) && !is_known_builtin_attr(attr) {
+                if let Some(name) = attr.path().get_ident().map(|i| i.to_string()) {
+                    macro_attrs.push(name);
+                }
+            }
+        }
+        if !derives.is_empty() {
+            self.sink.push_property(id, "derives", &derives.join(","));
+        }
+        if !macro_attrs.is_empty() {
+            self.sink
+                .push_property(id, "attribute_macros", &macro_attrs.join(","));
+        }
+    }
+}
+
+fn span_of<S: Spanned>(node: &S) -> Span {
+    span_from(node.span())
+}
+
+fn span_from(span: proc_macro2::Span) -> Span {
+    let LineColumn {
+        line: sl,
+        column: sc,
+    } = span.start();
+    let LineColumn {
+        line: el,
+        column: ec,
+    } = span.end();
+    Span {
+        start_line: sl as u32,
+        start_col: (sc + 1) as u32,
+        end_line: el as u32,
+        end_col: (ec + 1) as u32,
+    }
+}
+
+fn whole_file_span(file: &syn::File) -> Span {
+    if let (Some(first), Some(last)) = (file.items.first(), file.items.last()) {
+        let s = span_of(first);
+        let e = span_of(last);
+        Span {
+            start_line: 1,
+            start_col: 1,
+            end_line: e.end_line.max(s.end_line),
+            end_col: 1,
+        }
+    } else {
+        Span::point(1, 1)
+    }
+}
+
+fn doc_of_attrs(attrs: &[syn::Attribute]) -> Option<String> {
+    let mut out = String::new();
+    for attr in attrs {
+        if !is_doc_attr(attr) {
+            continue;
+        }
+        if let syn::Meta::NameValue(nv) = &attr.meta {
+            if let syn::Expr::Lit(syn::ExprLit {
+                lit: syn::Lit::Str(s),
+                ..
+            }) = &nv.value
+            {
+                if !out.is_empty() {
+                    out.push('\n');
+                }
+                let raw = s.value();
+                out.push_str(raw.strip_prefix(' ').unwrap_or(&raw));
+            }
+        }
+    }
+    if out.is_empty() {
+        None
+    } else {
+        Some(out)
+    }
+}
+
+fn is_doc_attr(attr: &syn::Attribute) -> bool {
+    attr.path().is_ident("doc")
+}
+
+fn is_known_builtin_attr(attr: &syn::Attribute) -> bool {
+    let path = attr.path();
+    [
+        "doc",
+        "derive",
+        "cfg",
+        "cfg_attr",
+        "allow",
+        "warn",
+        "deny",
+        "forbid",
+        "must_use",
+        "inline",
+        "non_exhaustive",
+        "repr",
+        "test",
+        "ignore",
+        "should_panic",
+        "bench",
+    ]
+    .iter()
+    .any(|s| path.is_ident(s))
+}
+
+fn path_of_type(ty: &syn::Type) -> Option<String> {
+    if let syn::Type::Path(tp) = ty {
+        Some(path_of_path(&tp.path))
+    } else {
+        None
+    }
+}
+
+fn path_of_path(p: &syn::Path) -> String {
+    p.segments
+        .iter()
+        .map(|s| s.ident.to_string())
+        .collect::<Vec<_>>()
+        .join("::")
+}
+
+/// If `s` parses as a simple `ident` (no `::`), return that ident; else
+/// `None` so callers know they cannot resolve cross-module within v1.
+fn simple_ident(s: &str) -> Option<&str> {
+    if s.contains("::") || s.is_empty() {
+        None
+    } else {
+        Some(s)
+    }
+}

--- a/yah-kg-rust/tests/index_then_query.rs
+++ b/yah-kg-rust/tests/index_then_query.rs
@@ -1,0 +1,262 @@
+//! End-to-end: parse a Rust source string with `RustIndexer`, push the
+//! results into a `Store`, then exercise the queries the daemon will
+//! expose under `arch.subgraph` / `arch.lookup` / `arch.neighbors`.
+
+use std::path::Path;
+use yah_kg::edge::EdgeKind;
+use yah_kg::indexer::LanguageIndexer;
+use yah_kg::kind::{CommonKind, Lang, NodeKind, RustKind};
+use yah_kg::rpc::Direction;
+use yah_kg_rust::RustIndexer;
+use yah_kg_store::{Store, StoreSink};
+
+const SRC: &str = r#"
+//! Toy mixer crate.
+
+/// Top-level mixer struct.
+#[derive(Debug, Clone)]
+pub struct AudioMixer {
+    pub gain: f32,
+    name: String,
+}
+
+pub trait Mixer {
+    fn mix(&self, lhs: f32, rhs: f32) -> f32;
+    fn name(&self) -> &str { "default" }
+}
+
+impl Mixer for AudioMixer {
+    fn mix(&self, lhs: f32, rhs: f32) -> f32 {
+        (lhs + rhs) * self.gain
+    }
+}
+
+impl AudioMixer {
+    pub fn new(gain: f32) -> Self {
+        AudioMixer { gain, name: String::new() }
+    }
+}
+
+pub enum Channel {
+    Left,
+    Right,
+    Mid,
+}
+
+mod inner {
+    pub fn helper() {}
+
+    macro_rules! noop {
+        () => {};
+    }
+}
+"#;
+
+fn build_store() -> Store {
+    let mut store = Store::new();
+    {
+        let mut sink = StoreSink::new(&mut store);
+        let indexer = RustIndexer::new();
+        indexer
+            .index_file(Path::new("src/mixer.rs"), SRC, &mut sink)
+            .expect("indexer should succeed on valid Rust");
+    }
+    store
+}
+
+#[test]
+fn indexer_emits_file_struct_trait_impl_enum_module() {
+    let store = build_store();
+
+    // Lookup at lines we know exist gets us the relevant nodes.
+    let at_struct = store.lookup("src/mixer.rs", Some(6));
+    assert!(!at_struct.is_empty(), "should hit AudioMixer at line 6");
+
+    // Query `arch.subgraph` from the file root, depth 2 — should reach the
+    // struct, trait, impls, enum, and module.
+    let file_id = at_struct
+        .iter()
+        .copied()
+        .find(|id| {
+            store
+                .node_ref(*id)
+                .map(|n| matches!(n.kind, NodeKind::Common(CommonKind::File)))
+                .unwrap_or(false)
+        })
+        .expect("file node should be reachable from any line lookup");
+
+    let sg = store.subgraph(file_id, 3, None, None, None, None);
+    let kinds: Vec<NodeKind> = sg.nodes.iter().map(|n| n.kind.clone()).collect();
+    let labels: Vec<String> = sg.nodes.iter().map(|n| n.label.clone()).collect();
+
+    assert!(
+        labels.iter().any(|l| l == "AudioMixer"),
+        "missing AudioMixer in {labels:?}"
+    );
+    assert!(
+        labels.iter().any(|l| l == "Mixer"),
+        "missing Mixer trait in {labels:?}"
+    );
+    assert!(
+        labels.iter().any(|l| l == "Channel"),
+        "missing Channel enum in {labels:?}"
+    );
+    assert!(
+        labels.iter().any(|l| l == "inner"),
+        "missing inner module in {labels:?}"
+    );
+    assert!(
+        labels.iter().any(|l| l == "Left"),
+        "missing variant Left in {labels:?}"
+    );
+    assert!(
+        labels.iter().any(|l| l == "gain"),
+        "missing field gain in {labels:?}"
+    );
+    assert!(
+        kinds
+            .iter()
+            .any(|k| matches!(k, NodeKind::Rust(RustKind::Trait))),
+        "no trait kind in {kinds:?}"
+    );
+    assert!(
+        kinds
+            .iter()
+            .any(|k| matches!(k, NodeKind::Rust(RustKind::Impl))),
+        "no impl kind in {kinds:?}"
+    );
+    assert!(
+        kinds
+            .iter()
+            .any(|k| matches!(k, NodeKind::Rust(RustKind::MacroDecl(_)))),
+        "no macro_rules! decl in {kinds:?}"
+    );
+}
+
+#[test]
+fn impl_for_and_impl_of_trait_edges_resolve_within_module() {
+    let store = build_store();
+
+    // Find the trait impl block (Mixer for AudioMixer) and verify both
+    // ImplFor → AudioMixer and ImplOfTrait → Mixer edges are in the store.
+    let all = store.lookup("src/mixer.rs", None);
+    let impl_node = all
+        .iter()
+        .copied()
+        .find(|id| {
+            store
+                .node_ref(*id)
+                .map(|n| {
+                    matches!(n.kind, NodeKind::Rust(RustKind::Impl))
+                        && n.label.starts_with("impl_Mixer_for_AudioMixer")
+                })
+                .unwrap_or(false)
+        })
+        .expect("trait impl should be indexed");
+
+    let out = store.neighbors(impl_node, Direction::Out, None);
+    let kinds: Vec<EdgeKind> = out.iter().map(|e| e.kind.clone()).collect();
+    assert!(
+        kinds.contains(&EdgeKind::ImplFor),
+        "ImplFor missing: {kinds:?}"
+    );
+    assert!(
+        kinds.contains(&EdgeKind::ImplOfTrait),
+        "ImplOfTrait missing: {kinds:?}"
+    );
+
+    // The impl-for target is AudioMixer; the impl-of-trait target is Mixer.
+    let impl_for = out
+        .iter()
+        .find(|e| e.kind == EdgeKind::ImplFor)
+        .expect("impl_for edge");
+    let impl_of = out
+        .iter()
+        .find(|e| e.kind == EdgeKind::ImplOfTrait)
+        .expect("impl_of_trait edge");
+
+    assert_eq!(
+        store.node_ref(impl_for.to).map(|n| n.label.as_str()),
+        Some("AudioMixer")
+    );
+    assert_eq!(
+        store.node_ref(impl_of.to).map(|n| n.label.as_str()),
+        Some("Mixer")
+    );
+}
+
+#[test]
+fn lookup_returns_innermost_first() {
+    let store = build_store();
+    // Line 18 is inside `fn mix` inside the trait impl block.
+    let hits = store.lookup("src/mixer.rs", Some(18));
+    let labels: Vec<String> = hits
+        .iter()
+        .filter_map(|id| store.node_ref(*id).map(|n| n.label.clone()))
+        .collect();
+    // First hit should be the most specific (the method), not the file.
+    assert!(
+        labels.first().is_some_and(|l| l == "mix"),
+        "expected innermost-first to surface `mix`; got {labels:?}"
+    );
+    let kinds: Vec<NodeKind> = hits
+        .iter()
+        .filter_map(|id| store.node_ref(*id).map(|n| n.kind.clone()))
+        .collect();
+    assert!(
+        kinds
+            .iter()
+            .any(|k| matches!(k, NodeKind::Common(CommonKind::File))),
+        "file should still appear among results: {labels:?}"
+    );
+}
+
+#[test]
+fn derives_recorded_as_property() {
+    let store = build_store();
+    let all = store.lookup("src/mixer.rs", None);
+    let mixer_id = all
+        .iter()
+        .copied()
+        .find(|id| {
+            store
+                .node_ref(*id)
+                .map(|n| n.label == "AudioMixer")
+                .unwrap_or(false)
+        })
+        .expect("AudioMixer node");
+    let full = store.node_full(mixer_id).expect("full node");
+    let derives = full.properties.get("derives").cloned().unwrap_or_default();
+    assert!(
+        derives.contains("Debug") && derives.contains("Clone"),
+        "expected Debug,Clone in derives property; got {derives:?}"
+    );
+    let type_kind = full
+        .properties
+        .get("type_kind")
+        .cloned()
+        .unwrap_or_default();
+    assert_eq!(type_kind, "struct");
+}
+
+#[test]
+fn parse_error_surfaces_as_index_error() {
+    let mut store = Store::new();
+    let bad = "fn broken( {";
+    let err = {
+        let mut sink = StoreSink::new(&mut store);
+        RustIndexer::new()
+            .index_file(Path::new("src/bad.rs"), bad, &mut sink)
+            .expect_err("invalid rust should error")
+    };
+    let msg = format!("{}", err);
+    assert!(msg.contains("src/bad.rs"), "error should mention path: {msg}");
+    assert_eq!(store.node_count(), 0, "no nodes should leak from parse failure");
+}
+
+#[test]
+fn rust_indexer_metadata_is_correct() {
+    let i = RustIndexer::new();
+    assert_eq!(i.lang(), Lang::Rust);
+    assert_eq!(i.extensions(), &["rs"]);
+}

--- a/yah-kg-store/Cargo.toml
+++ b/yah-kg-store/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "yah-kg-store"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "In-memory knowledge-graph store backing the yah daemon's arch.* RPCs"
+
+[dependencies]
+yah-kg = { path = "../yah-kg" }
+petgraph = "0.6"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+thiserror = "1.0"
+walkdir = "2.0"
+
+[dev-dependencies]
+tempfile = "3.0"
+yah-kg-rust = { path = "../yah-kg-rust" }

--- a/yah-kg-store/src/lib.rs
+++ b/yah-kg-store/src/lib.rs
@@ -1,0 +1,27 @@
+//! @arch:layer(kg)
+//! @arch:role(graph)
+//!
+//! `yah-kg-store` — in-memory knowledge-graph store.
+//!
+//! Holds a `petgraph::StableDiGraph` keyed by `NodeId`, side maps for full
+//! `NodeRef`/`EdgeOut` lookup, doc/property bags, and a `(file, line)`
+//! index for `arch.lookup`. Implements [`yah_kg::IndexSink`] so language
+//! indexers can write into it directly, and exposes query methods that
+//! match the `arch.*` RPC surface.
+//!
+//! Storage decisions:
+//! * `StableDiGraph` so node/edge removal preserves indices for the
+//!   incremental update path.
+//! * Side maps rather than node weights so cloning a `NodeRef` out of the
+//!   graph is one hashmap hit, not a graph walk.
+//! * `BTreeMap<String, Vec<(Span, NodeId)>>` per file for `arch.lookup`,
+//!   with results returned innermost-first (smallest span containing the
+//!   line, descending by nesting depth).
+
+pub mod sink;
+pub mod store;
+pub mod walker;
+
+pub use sink::StoreSink;
+pub use store::{Store, StoreError};
+pub use walker::{walk_and_index, IndexerRegistry, WalkSummary};

--- a/yah-kg-store/src/sink.rs
+++ b/yah-kg-store/src/sink.rs
@@ -1,0 +1,42 @@
+//! @arch:layer(kg)
+//! @arch:role(graph)
+//!
+//! `StoreSink` — `IndexSink` impl that writes into a [`Store`].
+//!
+//! Indexers see the trait surface from `yah-kg`; this is the concrete
+//! implementation the daemon owns. It dedupes nodes/edges by id and
+//! flushes properties/docs into the same side maps the queries read.
+
+use crate::store::Store;
+use yah_kg::edge::EdgeOut;
+use yah_kg::ids::{NodeId, NodeRef};
+use yah_kg::indexer::IndexSink;
+
+pub struct StoreSink<'a> {
+    store: &'a mut Store,
+}
+
+impl<'a> StoreSink<'a> {
+    pub fn new(store: &'a mut Store) -> Self {
+        Self { store }
+    }
+}
+
+impl<'a> IndexSink for StoreSink<'a> {
+    fn push_node(&mut self, node: NodeRef) {
+        self.store.upsert_node(node);
+    }
+
+    fn push_edge(&mut self, edge: EdgeOut) {
+        self.store.upsert_edge(edge);
+    }
+
+    fn push_property(&mut self, node: NodeId, key: &str, value: &str) {
+        self.store
+            .set_property(node, key.to_string(), value.to_string());
+    }
+
+    fn push_doc(&mut self, node: NodeId, doc: &str) {
+        self.store.set_doc(node, doc.to_string());
+    }
+}

--- a/yah-kg-store/src/store.rs
+++ b/yah-kg-store/src/store.rs
@@ -1,0 +1,533 @@
+//! @arch:layer(kg)
+//! @arch:role(graph)
+//!
+//! In-memory `Store` backing the `arch.*` RPC surface.
+
+use petgraph::stable_graph::{NodeIndex, StableDiGraph};
+use petgraph::visit::EdgeRef;
+use petgraph::Direction as PgDirection;
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
+use yah_kg::edge::{EdgeId, EdgeKind, EdgeOut};
+use yah_kg::ids::{NodeFull, NodeId, NodeRef, Span};
+use yah_kg::kind::{Lang, NodeKind};
+use yah_kg::rpc::{Direction, Subgraph};
+
+#[derive(Debug, thiserror::Error)]
+pub enum StoreError {
+    #[error("node not found: {0}")]
+    NodeNotFound(NodeId),
+}
+
+/// In-memory knowledge graph.
+///
+/// `Store` owns the petgraph and all side indices. Cloning is intentionally
+/// not derived — the graph is mutated in place from a single owner (the
+/// daemon) and queries borrow.
+pub struct Store {
+    graph: StableDiGraph<NodeId, EdgeId>,
+    node_index: HashMap<NodeId, NodeIndex>,
+    nodes: HashMap<NodeId, NodeRef>,
+    edges: HashMap<EdgeId, EdgeOut>,
+    docs: HashMap<NodeId, String>,
+    properties: HashMap<NodeId, BTreeMap<String, String>>,
+    by_file: HashMap<String, Vec<(Span, NodeId)>>,
+}
+
+impl Default for Store {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Store {
+    pub fn new() -> Self {
+        Self {
+            graph: StableDiGraph::new(),
+            node_index: HashMap::new(),
+            nodes: HashMap::new(),
+            edges: HashMap::new(),
+            docs: HashMap::new(),
+            properties: HashMap::new(),
+            by_file: HashMap::new(),
+        }
+    }
+
+    pub fn node_count(&self) -> usize {
+        self.nodes.len()
+    }
+
+    pub fn edge_count(&self) -> usize {
+        self.edges.len()
+    }
+
+    /// Insert a node, or replace its `NodeRef` (and refresh the file index)
+    /// if one already exists. Returns `true` when the node is new.
+    pub fn upsert_node(&mut self, node: NodeRef) -> bool {
+        let id = node.id;
+        let is_new = !self.node_index.contains_key(&id);
+        if is_new {
+            let idx = self.graph.add_node(id);
+            self.node_index.insert(id, idx);
+        } else {
+            let prev_file = self.nodes.get(&id).map(|n| n.file.clone());
+            if let Some(file) = prev_file {
+                self.remove_from_file_index(&file, id);
+            }
+        }
+        self.by_file
+            .entry(node.file.clone())
+            .or_default()
+            .push((node.span, id));
+        self.nodes.insert(id, node);
+        is_new
+    }
+
+    /// Insert an edge. Returns `true` when the edge is new. Both endpoints
+    /// must already exist; otherwise the edge is dropped silently (the
+    /// indexer pipeline guarantees ordering by emitting nodes first).
+    pub fn upsert_edge(&mut self, edge: EdgeOut) -> bool {
+        if self.edges.contains_key(&edge.id) {
+            return false;
+        }
+        let (Some(&from), Some(&to)) = (
+            self.node_index.get(&edge.from),
+            self.node_index.get(&edge.to),
+        ) else {
+            return false;
+        };
+        self.graph.add_edge(from, to, edge.id);
+        self.edges.insert(edge.id, edge);
+        true
+    }
+
+    pub fn remove_node(&mut self, id: NodeId) -> Option<NodeRef> {
+        let idx = self.node_index.remove(&id)?;
+        let edges_to_drop: Vec<EdgeId> = self
+            .graph
+            .edges(idx)
+            .map(|e| *e.weight())
+            .chain(
+                self.graph
+                    .edges_directed(idx, PgDirection::Incoming)
+                    .map(|e| *e.weight()),
+            )
+            .collect();
+        for eid in edges_to_drop {
+            self.edges.remove(&eid);
+        }
+        self.graph.remove_node(idx);
+        let node = self.nodes.remove(&id);
+        self.docs.remove(&id);
+        self.properties.remove(&id);
+        if let Some(n) = &node {
+            self.remove_from_file_index(&n.file, id);
+        }
+        node
+    }
+
+    pub fn remove_edge(&mut self, id: EdgeId) -> Option<EdgeOut> {
+        let edge = self.edges.remove(&id)?;
+        let from_idx = self.node_index.get(&edge.from).copied();
+        if let Some(idx) = from_idx {
+            let target = self
+                .graph
+                .edges(idx)
+                .find(|e| *e.weight() == id)
+                .map(|e| e.id());
+            if let Some(eid) = target {
+                self.graph.remove_edge(eid);
+            }
+        }
+        Some(edge)
+    }
+
+    pub fn set_doc(&mut self, id: NodeId, doc: String) {
+        self.docs.insert(id, doc);
+    }
+
+    pub fn set_property(&mut self, id: NodeId, key: String, value: String) {
+        self.properties.entry(id).or_default().insert(key, value);
+    }
+
+    pub fn node_ref(&self, id: NodeId) -> Option<&NodeRef> {
+        self.nodes.get(&id)
+    }
+
+    pub fn node_full(&self, id: NodeId) -> Option<NodeFull> {
+        let node = self.nodes.get(&id)?.clone();
+        Some(NodeFull {
+            node,
+            doc: self.docs.get(&id).cloned(),
+            properties: self.properties.get(&id).cloned().unwrap_or_default(),
+            annotations: Vec::new(),
+        })
+    }
+
+    /// Innermost-first lookup: returns nodes whose span contains `line`,
+    /// sorted by ascending span size (the most specific node first).
+    pub fn lookup(&self, file: &str, line: Option<u32>) -> Vec<NodeId> {
+        let Some(entries) = self.by_file.get(file) else {
+            return Vec::new();
+        };
+        let mut hits: Vec<&(Span, NodeId)> = match line {
+            Some(l) => entries.iter().filter(|(s, _)| s.contains_line(l)).collect(),
+            None => entries.iter().collect(),
+        };
+        hits.sort_by_key(|(s, _)| (s.end_line - s.start_line, s.start_line));
+        hits.into_iter().map(|(_, id)| *id).collect()
+    }
+
+    pub fn neighbors(
+        &self,
+        id: NodeId,
+        dir: Direction,
+        edge_filter: Option<&[EdgeKind]>,
+    ) -> Vec<EdgeOut> {
+        let Some(&idx) = self.node_index.get(&id) else {
+            return Vec::new();
+        };
+        let mut out = Vec::new();
+        let dirs: &[PgDirection] = match dir {
+            Direction::Out => &[PgDirection::Outgoing],
+            Direction::In => &[PgDirection::Incoming],
+            Direction::Both => &[PgDirection::Outgoing, PgDirection::Incoming],
+        };
+        for d in dirs {
+            for eref in self.graph.edges_directed(idx, *d) {
+                let eid = *eref.weight();
+                if let Some(edge) = self.edges.get(&eid) {
+                    if edge_kind_matches(&edge.kind, edge_filter) {
+                        out.push(edge.clone());
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    /// BFS subgraph from `root` to `depth` hops. Walks outgoing edges only;
+    /// the daemon can re-call with `Direction::In` for the reverse view.
+    /// Filters apply post-traversal so a depth-2 walk still terminates at
+    /// the requested depth even when some edges are filtered out.
+    pub fn subgraph(
+        &self,
+        root: NodeId,
+        depth: u8,
+        edge_filter: Option<&[EdgeKind]>,
+        kind_filter: Option<&[NodeKind]>,
+        lang_filter: Option<&[Lang]>,
+        node_limit: Option<u32>,
+    ) -> Subgraph {
+        let limit = node_limit.unwrap_or(2_000) as usize;
+        let mut nodes_out = Vec::new();
+        let mut edges_out = Vec::new();
+        let mut seen_nodes: HashSet<NodeId> = HashSet::new();
+        let mut seen_edges: HashSet<EdgeId> = HashSet::new();
+        let mut truncated = false;
+
+        let Some(&root_idx) = self.node_index.get(&root) else {
+            return Subgraph {
+                root,
+                nodes: nodes_out,
+                edges: edges_out,
+                truncated: false,
+            };
+        };
+
+        let mut queue: VecDeque<(NodeIndex, u8)> = VecDeque::new();
+        queue.push_back((root_idx, 0));
+        seen_nodes.insert(root);
+        if let Some(n) = self.nodes.get(&root) {
+            if node_passes(n, kind_filter, lang_filter) {
+                nodes_out.push(n.clone());
+            }
+        }
+
+        while let Some((idx, d)) = queue.pop_front() {
+            if d >= depth {
+                continue;
+            }
+            for eref in self.graph.edges(idx) {
+                let eid = *eref.weight();
+                let Some(edge) = self.edges.get(&eid) else {
+                    continue;
+                };
+                if !edge_kind_matches(&edge.kind, edge_filter) {
+                    continue;
+                }
+                let target = eref.target();
+                let target_id = self.graph[target];
+                if seen_nodes.insert(target_id) {
+                    if let Some(n) = self.nodes.get(&target_id) {
+                        if node_passes(n, kind_filter, lang_filter) {
+                            if nodes_out.len() >= limit {
+                                truncated = true;
+                                break;
+                            }
+                            nodes_out.push(n.clone());
+                        }
+                    }
+                    queue.push_back((target, d + 1));
+                }
+                if seen_edges.insert(eid) {
+                    edges_out.push(edge.clone());
+                }
+            }
+            if truncated {
+                break;
+            }
+        }
+
+        Subgraph {
+            root,
+            nodes: nodes_out,
+            edges: edges_out,
+            truncated,
+        }
+    }
+
+    /// Top-level entry-point nodes. With no filter this returns every
+    /// `Directory` and every `File` whose parent isn't itself in the
+    /// graph — the natural roots for the UI's first render.
+    pub fn roots(
+        &self,
+        lang_filter: Option<&[Lang]>,
+        kind_filter: Option<&[NodeKind]>,
+    ) -> Vec<NodeRef> {
+        let mut out: Vec<NodeRef> = self
+            .nodes
+            .values()
+            .filter(|n| node_passes(n, kind_filter, lang_filter))
+            .filter(|n| {
+                if kind_filter.is_some() {
+                    return true;
+                }
+                let Some(&idx) = self.node_index.get(&n.id) else {
+                    return false;
+                };
+                self.graph
+                    .edges_directed(idx, PgDirection::Incoming)
+                    .all(|e| !matches!(self.edges.get(e.weight()).map(|x| &x.kind),
+                        Some(EdgeKind::Contains)))
+            })
+            .cloned()
+            .collect();
+        out.sort_by(|a, b| a.qualified.cmp(&b.qualified));
+        out
+    }
+
+    pub fn stats(&self) -> StoreStats {
+        let mut by_lang: BTreeMap<String, u64> = BTreeMap::new();
+        let mut by_kind: BTreeMap<String, u64> = BTreeMap::new();
+        for n in self.nodes.values() {
+            *by_lang
+                .entry(serde_json::to_string(&n.lang).unwrap_or_default())
+                .or_insert(0) += 1;
+            *by_kind
+                .entry(short_kind_label(&n.kind))
+                .or_insert(0) += 1;
+        }
+        StoreStats {
+            node_count: self.nodes.len() as u64,
+            edge_count: self.edges.len() as u64,
+            by_lang,
+            by_kind,
+        }
+    }
+
+    fn remove_from_file_index(&mut self, file: &str, id: NodeId) {
+        if let Some(entries) = self.by_file.get_mut(file) {
+            entries.retain(|(_, nid)| *nid != id);
+            if entries.is_empty() {
+                self.by_file.remove(file);
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct StoreStats {
+    pub node_count: u64,
+    pub edge_count: u64,
+    pub by_lang: BTreeMap<String, u64>,
+    pub by_kind: BTreeMap<String, u64>,
+}
+
+fn node_passes(
+    node: &NodeRef,
+    kind_filter: Option<&[NodeKind]>,
+    lang_filter: Option<&[Lang]>,
+) -> bool {
+    if let Some(langs) = lang_filter {
+        if !langs.contains(&node.lang) {
+            return false;
+        }
+    }
+    if let Some(kinds) = kind_filter {
+        if !kinds.iter().any(|k| k == &node.kind) {
+            return false;
+        }
+    }
+    true
+}
+
+fn edge_kind_matches(kind: &EdgeKind, filter: Option<&[EdgeKind]>) -> bool {
+    match filter {
+        None => true,
+        Some(allowed) => allowed.iter().any(|k| k == kind),
+    }
+}
+
+fn short_kind_label(kind: &NodeKind) -> String {
+    match kind {
+        NodeKind::Common(c) => format!("common::{:?}", c).to_lowercase(),
+        NodeKind::Rust(r) => format!("rust::{:?}", r).to_lowercase(),
+        NodeKind::Ts(t) => format!("ts::{:?}", t).to_lowercase(),
+        NodeKind::Doc(d) => format!("doc::{:?}", d).to_lowercase(),
+        NodeKind::Koda(k) => format!("koda::{:?}", k).to_lowercase(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use yah_kg::edge::EdgeId;
+    use yah_kg::kind::{CommonKind, Lang, NodeKind};
+
+    fn mk_node(name: &str, file: &str, line: u32) -> NodeRef {
+        let qualified = format!("{}::{}", file, name);
+        NodeRef {
+            id: NodeId::compute(Lang::Rust, &qualified, file),
+            lang: Lang::Rust,
+            kind: NodeKind::Common(CommonKind::Function),
+            label: name.to_string(),
+            qualified,
+            file: file.to_string(),
+            span: Span {
+                start_line: line,
+                start_col: 1,
+                end_line: line + 5,
+                end_col: 1,
+            },
+            synthetic: false,
+        }
+    }
+
+    #[test]
+    fn upsert_node_then_lookup_by_line() {
+        let mut store = Store::new();
+        let n = mk_node("foo", "src/a.rs", 10);
+        let id = n.id;
+        assert!(store.upsert_node(n));
+
+        let hits = store.lookup("src/a.rs", Some(12));
+        assert_eq!(hits, vec![id]);
+
+        let miss = store.lookup("src/a.rs", Some(99));
+        assert!(miss.is_empty());
+    }
+
+    #[test]
+    fn lookup_returns_innermost_first() {
+        let mut store = Store::new();
+        let outer = NodeRef {
+            id: NodeId::compute(Lang::Rust, "outer", "f"),
+            lang: Lang::Rust,
+            kind: NodeKind::Common(CommonKind::Module),
+            label: "outer".into(),
+            qualified: "outer".into(),
+            file: "f".into(),
+            span: Span { start_line: 1, start_col: 1, end_line: 100, end_col: 1 },
+            synthetic: false,
+        };
+        let inner = NodeRef {
+            id: NodeId::compute(Lang::Rust, "inner", "f"),
+            lang: Lang::Rust,
+            kind: NodeKind::Common(CommonKind::Function),
+            label: "inner".into(),
+            qualified: "inner".into(),
+            file: "f".into(),
+            span: Span { start_line: 10, start_col: 1, end_line: 20, end_col: 1 },
+            synthetic: false,
+        };
+        let outer_id = outer.id;
+        let inner_id = inner.id;
+        store.upsert_node(outer);
+        store.upsert_node(inner);
+
+        let hits = store.lookup("f", Some(15));
+        assert_eq!(hits, vec![inner_id, outer_id]);
+    }
+
+    #[test]
+    fn upsert_edge_requires_endpoints() {
+        let mut store = Store::new();
+        let a = mk_node("a", "f", 1);
+        let b = mk_node("b", "f", 2);
+        let edge = EdgeOut {
+            id: EdgeId::compute(a.id, b.id, &EdgeKind::Calls),
+            from: a.id,
+            to: b.id,
+            kind: EdgeKind::Calls,
+            annotations: vec![],
+        };
+        // Endpoints not yet inserted; edge is dropped.
+        assert!(!store.upsert_edge(edge.clone()));
+        store.upsert_node(a);
+        store.upsert_node(b);
+        assert!(store.upsert_edge(edge.clone()));
+        assert!(!store.upsert_edge(edge)); // dedupe
+        assert_eq!(store.edge_count(), 1);
+    }
+
+    #[test]
+    fn subgraph_walks_to_depth() {
+        let mut store = Store::new();
+        let mut prev: Option<NodeId> = None;
+        let mut ids = Vec::new();
+        for i in 0..5 {
+            let n = mk_node(&format!("n{}", i), "f", i as u32 * 10);
+            let id = n.id;
+            ids.push(id);
+            store.upsert_node(n);
+            if let Some(p) = prev {
+                let e = EdgeOut {
+                    id: EdgeId::compute(p, id, &EdgeKind::Calls),
+                    from: p,
+                    to: id,
+                    kind: EdgeKind::Calls,
+                    annotations: vec![],
+                };
+                store.upsert_edge(e);
+            }
+            prev = Some(id);
+        }
+        let sg = store.subgraph(ids[0], 2, None, None, None, None);
+        // root + 2 hops → 3 nodes
+        assert_eq!(sg.nodes.len(), 3);
+        assert!(!sg.truncated);
+    }
+
+    #[test]
+    fn remove_node_drops_incident_edges() {
+        let mut store = Store::new();
+        let a = mk_node("a", "f", 1);
+        let b = mk_node("b", "f", 2);
+        let aid = a.id;
+        let bid = b.id;
+        store.upsert_node(a);
+        store.upsert_node(b);
+        let e = EdgeOut {
+            id: EdgeId::compute(aid, bid, &EdgeKind::Calls),
+            from: aid,
+            to: bid,
+            kind: EdgeKind::Calls,
+            annotations: vec![],
+        };
+        store.upsert_edge(e);
+        assert_eq!(store.edge_count(), 1);
+        store.remove_node(aid);
+        assert_eq!(store.node_count(), 1);
+        assert_eq!(store.edge_count(), 0);
+    }
+}

--- a/yah-kg-store/src/walker.rs
+++ b/yah-kg-store/src/walker.rs
@@ -1,0 +1,226 @@
+//! @arch:layer(kg)
+//! @arch:role(graph)
+//!
+//! Directory walker that drives a registry of `LanguageIndexer`s.
+//!
+//! This is the daemon's Pass 1: walk the rig, emit `Directory` and `File`
+//! nodes with `Contains` edges, then dispatch each file to the matching
+//! indexer for Pass 2 (in-file structure). Indexers are pure; the walker
+//! owns the file I/O.
+
+use crate::sink::StoreSink;
+use crate::store::Store;
+use std::path::Path;
+use walkdir::WalkDir;
+use yah_kg::edge::{EdgeId, EdgeKind, EdgeOut};
+use yah_kg::ids::{NodeId, NodeRef, Span};
+use yah_kg::indexer::{IndexError, LanguageIndexer};
+use yah_kg::kind::{CommonKind, Lang, NodeKind};
+
+/// Maps file extensions to the indexer that should handle them.
+pub struct IndexerRegistry {
+    indexers: Vec<Box<dyn LanguageIndexer>>,
+}
+
+impl Default for IndexerRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IndexerRegistry {
+    pub fn new() -> Self {
+        Self { indexers: Vec::new() }
+    }
+
+    pub fn register(&mut self, indexer: Box<dyn LanguageIndexer>) {
+        self.indexers.push(indexer);
+    }
+
+    /// First-match-wins lookup by file extension (lowercased, no dot).
+    pub fn for_extension(&self, ext: &str) -> Option<&dyn LanguageIndexer> {
+        let needle = ext.to_lowercase();
+        for ix in &self.indexers {
+            if ix.extensions().iter().any(|e| e.eq_ignore_ascii_case(&needle)) {
+                return Some(ix.as_ref());
+            }
+        }
+        None
+    }
+
+    pub fn languages(&self) -> Vec<Lang> {
+        self.indexers.iter().map(|i| i.lang()).collect()
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct WalkSummary {
+    pub files_seen: u32,
+    pub files_indexed: u32,
+    pub files_skipped: u32,
+    pub parse_errors: u32,
+}
+
+/// Walk `root`, emit Directory/File nodes + Contains edges, dispatch each
+/// recognized file to its indexer. Symlinks are not followed; hidden
+/// directories (leading `.`) and `target/` are skipped.
+pub fn walk_and_index(
+    root: &Path,
+    store: &mut Store,
+    registry: &IndexerRegistry,
+) -> Result<WalkSummary, IndexError> {
+    let mut summary = WalkSummary::default();
+    let root_canon = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+
+    for entry in WalkDir::new(&root_canon)
+        .follow_links(false)
+        .into_iter()
+        .filter_entry(|e| !is_skipped(e.path(), &root_canon))
+    {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        let path = entry.path();
+        let rel = relativize(path, &root_canon);
+
+        if entry.file_type().is_dir() {
+            push_directory(&rel, path, &root_canon, store);
+            continue;
+        }
+
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        summary.files_seen += 1;
+
+        let Some(ext) = path.extension().and_then(|s| s.to_str()) else {
+            summary.files_skipped += 1;
+            continue;
+        };
+        let Some(indexer) = registry.for_extension(ext) else {
+            summary.files_skipped += 1;
+            continue;
+        };
+
+        let file_node = push_file(&rel, indexer.lang(), path, &root_canon, store);
+
+        let src = match std::fs::read_to_string(path) {
+            Ok(s) => s,
+            Err(e) => {
+                return Err(IndexError::Io(format!("{}: {}", path.display(), e)));
+            }
+        };
+
+        let mut sink = StoreSink::new(store);
+        match indexer.index_file(Path::new(&rel), &src, &mut sink) {
+            Ok(()) => summary.files_indexed += 1,
+            Err(_) => summary.parse_errors += 1,
+        }
+
+        // Best-effort: link file → top-level items the indexer just produced
+        // is the indexer's job, not ours. We don't synthesize Contains here.
+        let _ = file_node;
+    }
+    Ok(summary)
+}
+
+fn is_skipped(path: &Path, root: &Path) -> bool {
+    if path == root {
+        return false;
+    }
+    let Some(name) = path.file_name().and_then(|s| s.to_str()) else {
+        return false;
+    };
+    if name == "target" || name == "node_modules" || name == ".git" {
+        return true;
+    }
+    name.starts_with('.') && name != "."
+}
+
+fn relativize(path: &Path, root: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn push_directory(rel: &str, abs: &Path, root: &Path, store: &mut Store) {
+    let label = abs
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or(rel)
+        .to_string();
+    let qualified = if rel.is_empty() { ".".to_string() } else { rel.to_string() };
+    let id = NodeId::compute(Lang::Rust, &qualified, &qualified);
+    let node = NodeRef {
+        id,
+        lang: Lang::Rust, // language-agnostic but Lang must be assigned
+        kind: NodeKind::Common(CommonKind::Directory),
+        label,
+        qualified: qualified.clone(),
+        file: qualified.clone(),
+        span: Span::point(1, 1),
+        synthetic: false,
+    };
+    store.upsert_node(node);
+
+    if let Some(parent) = abs.parent() {
+        if parent.starts_with(root) && parent != abs {
+            let parent_rel = relativize(parent, root);
+            let parent_qualified = if parent_rel.is_empty() {
+                ".".to_string()
+            } else {
+                parent_rel
+            };
+            let parent_id = NodeId::compute(Lang::Rust, &parent_qualified, &parent_qualified);
+            let edge = EdgeOut {
+                id: EdgeId::compute(parent_id, id, &EdgeKind::Contains),
+                from: parent_id,
+                to: id,
+                kind: EdgeKind::Contains,
+                annotations: vec![],
+            };
+            store.upsert_edge(edge);
+        }
+    }
+}
+
+fn push_file(rel: &str, lang: Lang, abs: &Path, root: &Path, store: &mut Store) -> NodeId {
+    let label = abs
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or(rel)
+        .to_string();
+    let id = NodeId::compute(lang, rel, rel);
+    let node = NodeRef {
+        id,
+        lang,
+        kind: NodeKind::Common(CommonKind::File),
+        label,
+        qualified: rel.to_string(),
+        file: rel.to_string(),
+        span: Span::point(1, 1),
+        synthetic: false,
+    };
+    store.upsert_node(node);
+
+    if let Some(parent) = abs.parent() {
+        let parent_rel = relativize(parent, root);
+        let parent_qualified = if parent_rel.is_empty() {
+            ".".to_string()
+        } else {
+            parent_rel
+        };
+        let parent_id = NodeId::compute(Lang::Rust, &parent_qualified, &parent_qualified);
+        let edge = EdgeOut {
+            id: EdgeId::compute(parent_id, id, &EdgeKind::Contains),
+            from: parent_id,
+            to: id,
+            kind: EdgeKind::Contains,
+            annotations: vec![],
+        };
+        store.upsert_edge(edge);
+    }
+    id
+}

--- a/yah-kg-store/tests/walker_e2e.rs
+++ b/yah-kg-store/tests/walker_e2e.rs
@@ -1,0 +1,95 @@
+//! End-to-end walker test: lay down a tiny rig on disk, drive
+//! `walk_and_index` with the registered `RustIndexer`, then query the
+//! store like the daemon will.
+
+use std::fs;
+use tempfile::tempdir;
+use yah_kg::edge::EdgeKind;
+use yah_kg::indexer::LanguageIndexer;
+use yah_kg::kind::{CommonKind, NodeKind};
+use yah_kg_rust::RustIndexer;
+use yah_kg_store::{walk_and_index, IndexerRegistry, Store};
+
+#[test]
+fn walks_directory_and_dispatches_to_rust_indexer() {
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("src");
+    fs::create_dir(&src).unwrap();
+    fs::write(
+        src.join("lib.rs"),
+        "pub struct Foo;\npub fn bar() {}\n",
+    )
+    .unwrap();
+    fs::write(
+        src.join("nested.rs"),
+        "pub trait Mixer { fn mix(&self); }\n",
+    )
+    .unwrap();
+    // A non-Rust file should be skipped.
+    fs::write(src.join("README.md"), "not rust").unwrap();
+    // A target/ directory should be skipped entirely.
+    let target = dir.path().join("target");
+    fs::create_dir(&target).unwrap();
+    fs::write(target.join("noise.rs"), "fn ignored() {}\n").unwrap();
+
+    let mut store = Store::new();
+    let mut registry = IndexerRegistry::new();
+    registry.register(Box::new(RustIndexer::new()));
+
+    let summary = walk_and_index(dir.path(), &mut store, &registry).unwrap();
+
+    assert_eq!(summary.files_indexed, 2, "lib.rs + nested.rs");
+    assert_eq!(summary.files_skipped, 1, "README.md");
+    assert_eq!(summary.parse_errors, 0);
+
+    // Find the Foo struct via the file index, not by walking.
+    let lib_hits = store.lookup("src/lib.rs", None);
+    let labels: Vec<String> = lib_hits
+        .iter()
+        .filter_map(|id| store.node_ref(*id).map(|n| n.label.clone()))
+        .collect();
+    assert!(labels.iter().any(|l| l == "Foo"));
+    assert!(labels.iter().any(|l| l == "bar"));
+
+    // target/ entries shouldn't be in the store.
+    let ignored = store.lookup("target/noise.rs", None);
+    assert!(
+        ignored.is_empty(),
+        "target/ should be skipped: {ignored:?}"
+    );
+
+    // The walker should have emitted Contains edges from the src directory
+    // node into both files.
+    let dir_hits = store.lookup("src", None);
+    let dir_id = dir_hits
+        .iter()
+        .copied()
+        .find(|id| {
+            store
+                .node_ref(*id)
+                .map(|n| matches!(n.kind, NodeKind::Common(CommonKind::Directory)))
+                .unwrap_or(false)
+        })
+        .expect("src/ directory node");
+    let out = store.neighbors(dir_id, yah_kg::rpc::Direction::Out, Some(&[EdgeKind::Contains]));
+    let targets: Vec<String> = out
+        .iter()
+        .filter_map(|e| store.node_ref(e.to).map(|n| n.label.clone()))
+        .collect();
+    assert!(
+        targets.contains(&"lib.rs".to_string())
+            && targets.contains(&"nested.rs".to_string()),
+        "expected lib.rs + nested.rs as children of src/, got {targets:?}"
+    );
+}
+
+#[test]
+fn registry_extension_lookup_is_case_insensitive() {
+    let mut reg = IndexerRegistry::new();
+    reg.register(Box::new(RustIndexer::new()));
+    assert!(reg.for_extension("rs").is_some());
+    assert!(reg.for_extension("RS").is_some());
+    assert!(reg.for_extension("py").is_none());
+    let langs = reg.languages();
+    assert_eq!(langs, vec![RustIndexer::new().lang()]);
+}


### PR DESCRIPTION
## Summary

This PR introduces two new crates that form the core of the knowledge graph infrastructure:

1. **`yah-kg-rust`**: A Rust language indexer that parses `.rs` files and extracts structural information (types, functions, traits, impls, etc.)
2. **`yah-kg-store`**: An in-memory graph store backed by `petgraph` that serves as the query engine for the daemon's RPC surface

Together, these implement Pass 1 (directory walking) and Pass 2 (within-file indexing) of the daemon's three-pass architecture.

## Key Changes

### `yah-kg-rust` Crate
- **`visit.rs`** (765 lines): Core AST walker that traverses a parsed `syn::File` and emits nodes/edges
  - Maintains module-path and parent-id stacks to establish containment hierarchy
  - Emits Rust-specific edges: `ImplFor`, `ImplOfTrait`, `Defines`
  - Records type kinds, async/unsafe properties, and derives/attributes
  - Handles structs, enums, unions, traits, impls, functions, constants, macros, and modules
  
- **`indexer.rs`**: Entry point implementing the `LanguageIndexer` trait
  - Parses Rust source with `syn::parse_file`
  - Creates a fresh `Walker` per file for thread-safe concurrent indexing

### `yah-kg-store` Crate
- **`store.rs`** (533 lines): In-memory graph store with petgraph backend
  - `StableDiGraph` for stable node/edge indices across mutations
  - Side maps for full node/edge metadata, docs, and properties
  - File-based spatial index for `lookup(file, line)` queries
  - Query methods: `neighbors()`, `subgraph()`, `roots()`, `lookup()`
  - Filtering by language, node kind, and edge kind
  
- **`walker.rs`**: Directory traversal and indexer dispatch
  - `IndexerRegistry`: Maps file extensions to language indexers
  - `walk_and_index()`: Walks filesystem, emits Directory/File nodes, dispatches to indexers
  - Skips `target/`, `.git/`, `node_modules/`, and hidden directories
  
- **`sink.rs`**: Concrete `IndexSink` implementation
  - Bridges indexers (which see the trait) to the store (concrete implementation)
  - Dedupes nodes/edges by ID

### Tests
- **`yah-kg-rust/tests/index_then_query.rs`**: End-to-end indexing + querying
  - Parses a toy mixer crate, verifies struct/trait/impl/enum/module extraction
  - Tests `ImplFor`/`ImplOfTrait` edge resolution
  - Validates innermost-first lookup ordering
  
- **`yah-kg-store/tests/walker_e2e.rs`**: Directory walking + dispatch
  - Creates temporary directory structure, walks it, verifies file indexing
  - Confirms skipping of non-Rust files and excluded directories

## Notable Implementation Details

- **Stable IDs**: Node IDs are computed deterministically from qualified names and file paths, enabling deduplication across multiple passes
- **Synthetic impl names**: Impl blocks get stable names by combining trait/type names with line numbers to distinguish multiple impls in one file
- **Lazy trait resolution**: Simple-ident-only resolution for `ImplFor`/`ImplOfTrait` edges; cross-file macro resolution deferred to Pass 3
- **Span tracking**: All nodes carry source span information for IDE integration and precise lookup
- **Property bags**: Async/unsafe/required/auto flags stored as properties rather than enum variants for extensibility

https://claude.ai/code/session_013L41vk65E8nx1xzCxNc4r2