### PR TITLE
yah-kg-ts: TypeScript / TSX indexer (tree-sitter), dogfooded against …

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,6 +713,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1143,6 +1155,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0203df02a3b6dd63575cc1d6e609edc2181c9a11867a271b25cfd2abff3ec5ca"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-typescript"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1448,7 +1488,7 @@ dependencies = [
 
 [[package]]
 name = "yah-kg-rust"
-version = "0.5.4"
+version = "0.6.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1459,7 +1499,7 @@ dependencies = [
 
 [[package]]
 name = "yah-kg-store"
-version = "0.5.4"
+version = "0.6.0"
 dependencies = [
  "petgraph",
  "serde",
@@ -1469,4 +1509,15 @@ dependencies = [
  "walkdir",
  "yah-kg",
  "yah-kg-rust",
+]
+
+[[package]]
+name = "yah-kg-ts"
+version = "0.6.0"
+dependencies = [
+ "tempfile",
+ "tree-sitter",
+ "tree-sitter-typescript",
+ "yah-kg",
+ "yah-kg-store",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "yah-kg",
     "yah-kg-store",
     "yah-kg-rust",
+    "yah-kg-ts",
 ]
 resolver = "2"
 

--- a/yah-kg-ts/Cargo.toml
+++ b/yah-kg-ts/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "yah-kg-ts"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "TypeScript / TSX language indexer for the yah knowledge graph"
+
+[dependencies]
+yah-kg = { path = "../yah-kg" }
+tree-sitter = "0.23"
+tree-sitter-typescript = "0.23"
+
+[dev-dependencies]
+yah-kg-store = { path = "../yah-kg-store" }
+tempfile = "3.0"

--- a/yah-kg-ts/src/indexer.rs
+++ b/yah-kg-ts/src/indexer.rs
@@ -1,0 +1,68 @@
+//! @arch:layer(kg_lang)
+//! @arch:role(extract)
+//!
+//! `TsIndexer` — entry point implementing `LanguageIndexer`.
+//!
+//! Picks the right tree-sitter grammar based on the file extension:
+//! `.ts` → `language_typescript`, `.tsx` → `language_tsx`. Both grammars
+//! produce mostly the same node kinds; the TSX grammar additionally
+//! recognizes JSX elements, which the walker uses to flag JSX components.
+
+use crate::visit::Walker;
+use std::path::Path;
+use yah_kg::indexer::{IndexError, IndexSink, LanguageIndexer};
+use yah_kg::kind::Lang;
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct TsIndexer;
+
+impl TsIndexer {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl LanguageIndexer for TsIndexer {
+    fn lang(&self) -> Lang {
+        Lang::Ts
+    }
+
+    fn extensions(&self) -> &[&'static str] {
+        &["ts", "tsx"]
+    }
+
+    fn index_file(
+        &self,
+        path: &Path,
+        src: &str,
+        sink: &mut dyn IndexSink,
+    ) -> Result<(), IndexError> {
+        let path_str = path.to_string_lossy().replace('\\', "/");
+        let is_tsx = path_str.ends_with(".tsx");
+
+        let language = if is_tsx {
+            tree_sitter_typescript::LANGUAGE_TSX.into()
+        } else {
+            tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into()
+        };
+
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&language)
+            .map_err(|e| IndexError::Other(format!("set_language: {e}")))?;
+
+        let tree = parser
+            .parse(src, None)
+            .ok_or_else(|| IndexError::Parse {
+                path: path_str.clone(),
+                message: "parser returned None".into(),
+            })?;
+
+        // tree-sitter is permissive — it produces a tree with ERROR nodes
+        // rather than failing. We don't bail on errors; the walker just
+        // skips ERROR-tagged subtrees.
+        let mut walker = Walker::new(&path_str, src.as_bytes(), is_tsx, sink);
+        walker.run(tree.root_node());
+        Ok(())
+    }
+}

--- a/yah-kg-ts/src/lib.rs
+++ b/yah-kg-ts/src/lib.rs
@@ -1,0 +1,33 @@
+//! @arch:layer(kg_lang)
+//! @arch:role(extract)
+//!
+//! `yah-kg-ts` — `LanguageIndexer` for TypeScript and TSX (with React JSX).
+//!
+//! Pass 1+2 within-file indexer built on `tree-sitter-typescript`. For each
+//! source file we emit:
+//!
+//! * **Nodes:** `File`, `Module` (TS namespace / `module {}` block), `Type`
+//!   (class), `Field`, `Variant` (enum member), `Function`, `Method`,
+//!   `Constant` (top-level `const` / `let`), plus the TS-specific
+//!   `Interface`, `TypeAlias`, `Enum`, `JsxComponent`.
+//! * **Edges:** `Contains` (always), `Defines` (class/interface → method),
+//!   `Extends` (class extends class, interface extends interface), and
+//!   `DecoratedBy` (item → decorator) when an in-file decorator is found.
+//! * **Properties:** `type_kind`, `decorators`, `abstract`, `async`,
+//!   `default_export`, `tsx`, `extends_target` (the unresolved name of an
+//!   inherited class/interface — Pass 3 cross-file resolution will turn
+//!   this into proper edges).
+//!
+//! Cross-file resolution (`Imports`, `Calls`, `import { Foo } from "./bar"`
+//! → `Foo` node lookup) is intentionally Pass 3 daemon work.
+//!
+//! Choice of parser: `tree-sitter-typescript` over `swc_ecma_parser`. The
+//! tree-sitter substrate is the same one we'll use for Python, Go, etc.,
+//! so investing in the walker shape now pays off across languages. The
+//! cost is matching on `&'static str` node kinds rather than typed enums;
+//! we centralize those strings in `node_kind` constants below.
+
+pub mod indexer;
+pub mod visit;
+
+pub use indexer::TsIndexer;

--- a/yah-kg-ts/src/visit.rs
+++ b/yah-kg-ts/src/visit.rs
@@ -1,0 +1,698 @@
+//! @arch:layer(kg_lang)
+//! @arch:role(traverse)
+//!
+//! Tree-sitter-based walker over a parsed TypeScript / TSX source tree.
+//!
+//! The grammar is permissive: malformed source still parses into a tree
+//! with `ERROR`/`MISSING` nodes. We tolerate that — any unrecognized or
+//! errored subtree is silently skipped.
+//!
+//! What we recurse into:
+//! * the program root,
+//! * `export_statement` (transparent wrapper),
+//! * `class_body` / `interface_body` / `enum_body`,
+//! * `internal_module` / `module` bodies (TS namespaces).
+//!
+//! What we do NOT recurse into:
+//! * function/method bodies (locals are not graph-worthy in Pass 1+2),
+//! * type expressions (no `References` edges yet),
+//! * import/export bindings (cross-file work is Pass 3).
+
+use tree_sitter::Node;
+use yah_kg::edge::{EdgeId, EdgeKind, EdgeOut};
+use yah_kg::ids::{NodeId, NodeRef, Span};
+use yah_kg::indexer::IndexSink;
+use yah_kg::kind::{CommonKind, Lang, NodeKind, TsKind};
+
+const LANG: Lang = Lang::Ts;
+
+mod kind {
+    pub const CLASS: &str = "class_declaration";
+    pub const ABSTRACT_CLASS: &str = "abstract_class_declaration";
+    pub const INTERFACE: &str = "interface_declaration";
+    pub const TYPE_ALIAS: &str = "type_alias_declaration";
+    pub const ENUM: &str = "enum_declaration";
+    pub const FUNCTION: &str = "function_declaration";
+    pub const FUNCTION_SIG: &str = "function_signature";
+    pub const LEXICAL_DECL: &str = "lexical_declaration";
+    pub const VARIABLE_DECL: &str = "variable_declaration";
+    pub const NAMESPACE: &str = "internal_module";
+    pub const MODULE: &str = "module";
+    pub const EXPORT: &str = "export_statement";
+    pub const EXPR_STMT: &str = "expression_statement";
+    pub const AMBIENT_DECL: &str = "ambient_declaration";
+    pub const METHOD: &str = "method_definition";
+    pub const METHOD_SIG: &str = "method_signature";
+    pub const ABSTRACT_METHOD: &str = "abstract_method_signature";
+    pub const PUBLIC_FIELD: &str = "public_field_definition";
+    pub const PROPERTY_SIG: &str = "property_signature";
+    pub const ENUM_ASSIGN: &str = "enum_assignment";
+    pub const PROPERTY_IDENT: &str = "property_identifier";
+    pub const CLASS_HERITAGE: &str = "class_heritage";
+    pub const EXTENDS_CLAUSE: &str = "extends_clause";
+    pub const EXTENDS_TYPE_CLAUSE: &str = "extends_type_clause";
+    pub const IMPLEMENTS_CLAUSE: &str = "implements_clause";
+    pub const DECORATOR: &str = "decorator";
+    pub const CLASS_BODY: &str = "class_body";
+    pub const INTERFACE_BODY: &str = "interface_body";
+    pub const OBJECT_TYPE: &str = "object_type";
+    pub const ENUM_BODY: &str = "enum_body";
+    pub const VARIABLE_DECLARATOR: &str = "variable_declarator";
+    pub const ARROW_FUNCTION: &str = "arrow_function";
+    pub const FUNCTION_EXPR: &str = "function_expression";
+    pub const IDENTIFIER: &str = "identifier";
+    pub const TYPE_IDENT: &str = "type_identifier";
+    pub const NESTED_TYPE_IDENT: &str = "nested_type_identifier";
+    pub const JSX_ELEMENT: &str = "jsx_element";
+    pub const JSX_SELF_CLOSING: &str = "jsx_self_closing_element";
+    pub const JSX_FRAGMENT: &str = "jsx_fragment";
+}
+
+pub struct Walker<'a> {
+    file: String,
+    file_id: NodeId,
+    src: &'a [u8],
+    is_tsx: bool,
+    parents: Vec<NodeId>,
+    mod_path: Vec<String>,
+    sink: &'a mut dyn IndexSink,
+}
+
+impl<'a> Walker<'a> {
+    pub fn new(file: &str, src: &'a [u8], is_tsx: bool, sink: &'a mut dyn IndexSink) -> Self {
+        let file = file.replace('\\', "/");
+        let file_id = NodeId::compute(LANG, &file, &file);
+        Self {
+            file,
+            file_id,
+            src,
+            is_tsx,
+            parents: Vec::new(),
+            mod_path: Vec::new(),
+            sink,
+        }
+    }
+
+    pub fn run(&mut self, root: Node) {
+        let label = self
+            .file
+            .rsplit_once('/')
+            .map(|(_, n)| n.to_string())
+            .unwrap_or_else(|| self.file.clone());
+
+        self.sink.push_node(NodeRef {
+            id: self.file_id,
+            lang: LANG,
+            kind: NodeKind::Common(CommonKind::File),
+            label,
+            qualified: self.file.clone(),
+            file: self.file.clone(),
+            span: span_of(root),
+            synthetic: false,
+        });
+        if self.is_tsx {
+            self.sink.push_property(self.file_id, "tsx", "true");
+        }
+
+        self.parents.push(self.file_id);
+        let mut cursor = root.walk();
+        for child in root.children(&mut cursor) {
+            self.walk_top(child, false);
+        }
+        self.parents.pop();
+    }
+
+    fn current_parent(&self) -> NodeId {
+        *self.parents.last().expect("parent stack invariant")
+    }
+
+    fn qualify(&self, name: &str) -> String {
+        if self.mod_path.is_empty() {
+            format!("{}::{}", self.file, name)
+        } else {
+            format!("{}::{}::{}", self.file, self.mod_path.join("::"), name)
+        }
+    }
+
+    fn make_id(&self, qualified: &str) -> NodeId {
+        NodeId::compute(LANG, qualified, &self.file)
+    }
+
+    fn emit_contains(&mut self, parent: NodeId, child: NodeId) {
+        self.sink.push_edge(EdgeOut {
+            id: EdgeId::compute(parent, child, &EdgeKind::Contains),
+            from: parent,
+            to: child,
+            kind: EdgeKind::Contains,
+            annotations: vec![],
+        });
+    }
+
+    fn emit_edge(&mut self, from: NodeId, to: NodeId, edge: EdgeKind) {
+        self.sink.push_edge(EdgeOut {
+            id: EdgeId::compute(from, to, &edge),
+            from,
+            to,
+            kind: edge,
+            annotations: vec![],
+        });
+    }
+
+    fn walk_top(&mut self, node: Node, is_default_export: bool) {
+        let mut is_default = is_default_export;
+        match node.kind() {
+            kind::EXPORT => {
+                // `export ...`. May be `export default` and may wrap a decl.
+                if has_token_child(node, "default") {
+                    is_default = true;
+                }
+                let mut cursor = node.walk();
+                for child in node.children(&mut cursor) {
+                    if matches!(
+                        child.kind(),
+                        kind::CLASS
+                            | kind::ABSTRACT_CLASS
+                            | kind::INTERFACE
+                            | kind::TYPE_ALIAS
+                            | kind::ENUM
+                            | kind::FUNCTION
+                            | kind::FUNCTION_SIG
+                            | kind::LEXICAL_DECL
+                            | kind::VARIABLE_DECL
+                            | kind::NAMESPACE
+                            | kind::MODULE
+                    ) {
+                        self.walk_top(child, is_default);
+                    }
+                }
+            }
+            kind::CLASS | kind::ABSTRACT_CLASS => self.walk_class(node, is_default),
+            kind::INTERFACE => self.walk_interface(node, is_default),
+            kind::TYPE_ALIAS => self.walk_type_alias(node, is_default),
+            kind::ENUM => self.walk_enum(node, is_default),
+            kind::FUNCTION | kind::FUNCTION_SIG => self.walk_function(node, is_default),
+            kind::LEXICAL_DECL | kind::VARIABLE_DECL => self.walk_var_decl(node, is_default),
+            kind::NAMESPACE | kind::MODULE => self.walk_namespace(node),
+            // tree-sitter wraps `namespace foo {}` in an expression_statement
+            // because the `namespace` keyword isn't reserved; descend through.
+            // Same story for `declare namespace foo {}` → ambient_declaration.
+            kind::EXPR_STMT | kind::AMBIENT_DECL => {
+                let mut cursor = node.walk();
+                for child in node.children(&mut cursor) {
+                    self.walk_top(child, is_default);
+                }
+            }
+            // Imports skipped intentionally — Pass 3.
+            _ => {}
+        }
+    }
+
+    fn walk_class(&mut self, node: Node, is_default: bool) {
+        let name = field_name_text(node, "name", self.src).unwrap_or("anonymous_class");
+        let qualified = self.qualify(name);
+        let id = self.make_id(&qualified);
+        let parent = self.current_parent();
+
+        // JSX components: capitalized class in a .tsx file. We use the same
+        // heuristic as the function path — capitalized name in .tsx — rather
+        // than scanning method bodies for JSX returns.
+        let kind = if self.is_tsx && starts_with_uppercase(name) {
+            NodeKind::Ts(TsKind::JsxComponent)
+        } else {
+            NodeKind::Common(CommonKind::Type)
+        };
+
+        self.sink.push_node(NodeRef {
+            id,
+            lang: LANG,
+            kind,
+            label: name.to_string(),
+            qualified,
+            file: self.file.clone(),
+            span: span_of(node),
+            synthetic: false,
+        });
+        self.emit_contains(parent, id);
+        self.sink.push_property(id, "type_kind", "class");
+        if node.kind() == kind::ABSTRACT_CLASS {
+            self.sink.push_property(id, "abstract", "true");
+        }
+        if is_default {
+            self.sink.push_property(id, "default_export", "true");
+        }
+        self.record_decorators(node, id);
+
+        // Heritage: class_heritage may contain extends_clause and implements_clause.
+        if let Some(heritage) = first_child_of_kind(node, kind::CLASS_HERITAGE) {
+            let mut hcursor = heritage.walk();
+            for child in heritage.children(&mut hcursor) {
+                match child.kind() {
+                    kind::EXTENDS_CLAUSE => {
+                        if let Some(target) = first_descendant_kind(child, kind::IDENTIFIER)
+                            .or_else(|| first_descendant_kind(child, kind::TYPE_IDENT))
+                        {
+                            let target_name =
+                                node_text(target, self.src).to_string();
+                            self.sink.push_property(id, "extends_target", &target_name);
+                            // Best-effort same-file edge: only emit if a same-file
+                            // node already shares the qualified name we'd compute.
+                            self.maybe_emit_extends(id, &target_name);
+                        }
+                    }
+                    kind::IMPLEMENTS_CLAUSE => {
+                        let mut icursor = child.walk();
+                        for cand in child.children(&mut icursor) {
+                            if matches!(cand.kind(), kind::TYPE_IDENT | kind::IDENTIFIER) {
+                                let target_name = node_text(cand, self.src).to_string();
+                                self.sink.push_property(id, "implements_target", &target_name);
+                                self.maybe_emit_implements(id, &target_name);
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        // Class body: walk methods + fields.
+        if let Some(body) = first_child_of_kind(node, kind::CLASS_BODY) {
+            self.parents.push(id);
+            let mut cursor = body.walk();
+            let qualified_class = self.qualify(name);
+            for member in body.children(&mut cursor) {
+                self.walk_class_member(&qualified_class, id, member);
+            }
+            self.parents.pop();
+        }
+    }
+
+    fn walk_class_member(&mut self, parent_qualified: &str, parent_id: NodeId, node: Node) {
+        match node.kind() {
+            kind::METHOD | kind::ABSTRACT_METHOD | kind::METHOD_SIG => {
+                let Some(name) = field_name_text(node, "name", self.src) else {
+                    return;
+                };
+                let qualified = format!("{}::{}", parent_qualified, name);
+                let id = self.make_id(&qualified);
+                self.sink.push_node(NodeRef {
+                    id,
+                    lang: LANG,
+                    kind: NodeKind::Common(CommonKind::Method),
+                    label: name.to_string(),
+                    qualified,
+                    file: self.file.clone(),
+                    span: span_of(node),
+                    synthetic: false,
+                });
+                self.emit_contains(parent_id, id);
+                self.emit_edge(parent_id, id, EdgeKind::Defines);
+                if has_token_child(node, "async") {
+                    self.sink.push_property(id, "async", "true");
+                }
+                if matches!(node.kind(), kind::ABSTRACT_METHOD) {
+                    self.sink.push_property(id, "abstract", "true");
+                }
+                if matches!(node.kind(), kind::METHOD_SIG | kind::ABSTRACT_METHOD) {
+                    self.sink.push_property(id, "required", "true");
+                }
+                self.record_decorators(node, id);
+            }
+            kind::PUBLIC_FIELD | kind::PROPERTY_SIG => {
+                let Some(name) = field_name_text(node, "name", self.src) else {
+                    return;
+                };
+                let qualified = format!("{}::{}", parent_qualified, name);
+                let id = self.make_id(&qualified);
+                self.sink.push_node(NodeRef {
+                    id,
+                    lang: LANG,
+                    kind: NodeKind::Common(CommonKind::Field),
+                    label: name.to_string(),
+                    qualified,
+                    file: self.file.clone(),
+                    span: span_of(node),
+                    synthetic: false,
+                });
+                self.emit_contains(parent_id, id);
+                self.record_decorators(node, id);
+            }
+            _ => {}
+        }
+    }
+
+    fn walk_interface(&mut self, node: Node, is_default: bool) {
+        let name = field_name_text(node, "name", self.src).unwrap_or("anonymous_interface");
+        let qualified = self.qualify(name);
+        let id = self.make_id(&qualified);
+        let parent = self.current_parent();
+
+        self.sink.push_node(NodeRef {
+            id,
+            lang: LANG,
+            kind: NodeKind::Ts(TsKind::Interface),
+            label: name.to_string(),
+            qualified,
+            file: self.file.clone(),
+            span: span_of(node),
+            synthetic: false,
+        });
+        self.emit_contains(parent, id);
+        if is_default {
+            self.sink.push_property(id, "default_export", "true");
+        }
+
+        // extends_type_clause appears before the body.
+        if let Some(ext) = first_child_of_kind(node, kind::EXTENDS_TYPE_CLAUSE) {
+            let mut cursor = ext.walk();
+            for cand in ext.children(&mut cursor) {
+                if matches!(cand.kind(), kind::TYPE_IDENT | kind::NESTED_TYPE_IDENT) {
+                    let target = node_text(cand, self.src).to_string();
+                    self.sink.push_property(id, "extends_target", &target);
+                    self.maybe_emit_extends(id, &target);
+                }
+            }
+        }
+
+        // Interface body: object_type with property_signature / method_signature.
+        if let Some(body) =
+            first_child_of_kind(node, kind::OBJECT_TYPE).or_else(|| first_child_of_kind(node, kind::INTERFACE_BODY))
+        {
+            self.parents.push(id);
+            let qualified_iface = self.qualify(name);
+            let mut cursor = body.walk();
+            for member in body.children(&mut cursor) {
+                self.walk_class_member(&qualified_iface, id, member);
+            }
+            self.parents.pop();
+        }
+    }
+
+    fn walk_type_alias(&mut self, node: Node, is_default: bool) {
+        let name = field_name_text(node, "name", self.src).unwrap_or("anonymous_alias");
+        let qualified = self.qualify(name);
+        let id = self.make_id(&qualified);
+        let parent = self.current_parent();
+        self.sink.push_node(NodeRef {
+            id,
+            lang: LANG,
+            kind: NodeKind::Ts(TsKind::TypeAlias),
+            label: name.to_string(),
+            qualified,
+            file: self.file.clone(),
+            span: span_of(node),
+            synthetic: false,
+        });
+        self.emit_contains(parent, id);
+        if is_default {
+            self.sink.push_property(id, "default_export", "true");
+        }
+    }
+
+    fn walk_enum(&mut self, node: Node, is_default: bool) {
+        let name = field_name_text(node, "name", self.src).unwrap_or("anonymous_enum");
+        let qualified = self.qualify(name);
+        let id = self.make_id(&qualified);
+        let parent = self.current_parent();
+        self.sink.push_node(NodeRef {
+            id,
+            lang: LANG,
+            kind: NodeKind::Ts(TsKind::Enum),
+            label: name.to_string(),
+            qualified,
+            file: self.file.clone(),
+            span: span_of(node),
+            synthetic: false,
+        });
+        self.emit_contains(parent, id);
+        if is_default {
+            self.sink.push_property(id, "default_export", "true");
+        }
+
+        // Variants
+        if let Some(body) = first_child_of_kind(node, kind::ENUM_BODY) {
+            let qualified_enum = self.qualify(name);
+            let mut cursor = body.walk();
+            for member in body.children(&mut cursor) {
+                let v_name = match member.kind() {
+                    kind::PROPERTY_IDENT => Some(node_text(member, self.src)),
+                    kind::ENUM_ASSIGN => field_name_text(member, "name", self.src),
+                    _ => None,
+                };
+                let Some(v_name) = v_name else { continue };
+                let v_qualified = format!("{}::{}", qualified_enum, v_name);
+                let v_id = self.make_id(&v_qualified);
+                self.sink.push_node(NodeRef {
+                    id: v_id,
+                    lang: LANG,
+                    kind: NodeKind::Common(CommonKind::Variant),
+                    label: v_name.to_string(),
+                    qualified: v_qualified,
+                    file: self.file.clone(),
+                    span: span_of(member),
+                    synthetic: false,
+                });
+                self.emit_contains(id, v_id);
+            }
+        }
+    }
+
+    fn walk_function(&mut self, node: Node, is_default: bool) {
+        let name = field_name_text(node, "name", self.src).unwrap_or("anonymous");
+        let qualified = self.qualify(name);
+        let id = self.make_id(&qualified);
+        let parent = self.current_parent();
+
+        // JSX heuristic: capitalized name in a .tsx file → JsxComponent.
+        let kind = if self.is_tsx && starts_with_uppercase(name) {
+            NodeKind::Ts(TsKind::JsxComponent)
+        } else {
+            NodeKind::Common(CommonKind::Function)
+        };
+
+        self.sink.push_node(NodeRef {
+            id,
+            lang: LANG,
+            kind,
+            label: name.to_string(),
+            qualified,
+            file: self.file.clone(),
+            span: span_of(node),
+            synthetic: false,
+        });
+        self.emit_contains(parent, id);
+        if has_token_child(node, "async") {
+            self.sink.push_property(id, "async", "true");
+        }
+        if node.kind() == kind::FUNCTION_SIG {
+            self.sink.push_property(id, "ambient", "true");
+        }
+        if is_default {
+            self.sink.push_property(id, "default_export", "true");
+        }
+    }
+
+    fn walk_var_decl(&mut self, node: Node, is_default: bool) {
+        // Top-level lexical/variable declarations. Each declarator becomes a
+        // Constant node (or a JsxComponent if the value is a function and the
+        // name is capitalized in a .tsx file).
+        let mut cursor = node.walk();
+        for decl in node.children(&mut cursor) {
+            if decl.kind() != kind::VARIABLE_DECLARATOR {
+                continue;
+            }
+            let Some(name) = field_name_text(decl, "name", self.src) else {
+                continue;
+            };
+            let qualified = self.qualify(name);
+            let id = self.make_id(&qualified);
+            let parent = self.current_parent();
+
+            // Detect arrow / function expression value.
+            let value = decl.child_by_field_name("value");
+            let is_function_value = value
+                .map(|v| matches!(v.kind(), kind::ARROW_FUNCTION | kind::FUNCTION_EXPR))
+                .unwrap_or(false);
+
+            let kind = if self.is_tsx && is_function_value && starts_with_uppercase(name) {
+                NodeKind::Ts(TsKind::JsxComponent)
+            } else if is_function_value {
+                NodeKind::Common(CommonKind::Function)
+            } else {
+                NodeKind::Common(CommonKind::Constant)
+            };
+
+            self.sink.push_node(NodeRef {
+                id,
+                lang: LANG,
+                kind,
+                label: name.to_string(),
+                qualified,
+                file: self.file.clone(),
+                span: span_of(decl),
+                synthetic: false,
+            });
+            self.emit_contains(parent, id);
+            if is_default {
+                self.sink.push_property(id, "default_export", "true");
+            }
+            if let Some(v) = value {
+                if has_jsx_descendant(v) {
+                    self.sink.push_property(id, "returns_jsx", "true");
+                }
+            }
+        }
+    }
+
+    fn walk_namespace(&mut self, node: Node) {
+        let Some(name) = field_name_text(node, "name", self.src) else {
+            return;
+        };
+        let qualified = self.qualify(name);
+        let id = self.make_id(&qualified);
+        let parent = self.current_parent();
+        self.sink.push_node(NodeRef {
+            id,
+            lang: LANG,
+            kind: NodeKind::Common(CommonKind::Module),
+            label: name.to_string(),
+            qualified,
+            file: self.file.clone(),
+            span: span_of(node),
+            synthetic: false,
+        });
+        self.emit_contains(parent, id);
+
+        // Body: a statement_block under field "body".
+        if let Some(body) = node.child_by_field_name("body") {
+            self.mod_path.push(name.to_string());
+            self.parents.push(id);
+            let mut cursor = body.walk();
+            for child in body.children(&mut cursor) {
+                self.walk_top(child, false);
+            }
+            self.parents.pop();
+            self.mod_path.pop();
+        }
+    }
+
+    fn record_decorators(&mut self, node: Node, target: NodeId) {
+        let mut names: Vec<String> = Vec::new();
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            if child.kind() != kind::DECORATOR {
+                continue;
+            }
+            // Decorator child is either an identifier, member_expression,
+            // or call_expression. Pull the leftmost identifier.
+            if let Some(ident) = first_descendant_kind(child, kind::IDENTIFIER)
+                .or_else(|| first_descendant_kind(child, kind::PROPERTY_IDENT))
+            {
+                names.push(node_text(ident, self.src).to_string());
+            }
+        }
+        if !names.is_empty() {
+            self.sink.push_property(target, "decorators", &names.join(","));
+        }
+    }
+
+    fn maybe_emit_extends(&mut self, from: NodeId, target_name: &str) {
+        // Only emit when the target name is a simple ident we can resolve to a
+        // same-module qualified id. The store will silently drop dangling edges
+        // if no node with that id was emitted.
+        if target_name.contains('.') || target_name.contains("::") {
+            return;
+        }
+        let target_qualified = self.qualify(target_name);
+        let target_id = self.make_id(&target_qualified);
+        self.emit_edge(from, target_id, EdgeKind::Extends);
+    }
+
+    fn maybe_emit_implements(&mut self, from: NodeId, target_name: &str) {
+        if target_name.contains('.') || target_name.contains("::") {
+            return;
+        }
+        let target_qualified = self.qualify(target_name);
+        let target_id = self.make_id(&target_qualified);
+        self.emit_edge(from, target_id, EdgeKind::Implements);
+    }
+}
+
+// ----- helpers -----
+
+fn span_of(node: Node) -> Span {
+    let s = node.start_position();
+    let e = node.end_position();
+    Span {
+        start_line: (s.row + 1) as u32,
+        start_col: (s.column + 1) as u32,
+        end_line: (e.row + 1) as u32,
+        end_col: (e.column + 1) as u32,
+    }
+}
+
+fn node_text<'a>(node: Node, src: &'a [u8]) -> &'a str {
+    node.utf8_text(src).unwrap_or("")
+}
+
+fn field_name_text<'a>(node: Node, field: &str, src: &'a [u8]) -> Option<&'a str> {
+    node.child_by_field_name(field)
+        .and_then(|n| n.utf8_text(src).ok())
+}
+
+fn first_child_of_kind<'a>(node: Node<'a>, kind: &str) -> Option<Node<'a>> {
+    for i in 0..node.child_count() {
+        let c = node.child(i)?;
+        if c.kind() == kind {
+            return Some(c);
+        }
+    }
+    None
+}
+
+fn first_descendant_kind<'a>(node: Node<'a>, kind: &str) -> Option<Node<'a>> {
+    for i in 0..node.child_count() {
+        let child = node.child(i)?;
+        if child.kind() == kind {
+            return Some(child);
+        }
+        if let Some(found) = first_descendant_kind(child, kind) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+/// True if the node has an immediate child whose kind() matches `tok`.
+/// Used to detect anonymous keyword tokens like `default`, `async`,
+/// `abstract` that aren't always exposed as fields.
+fn has_token_child(node: Node, tok: &str) -> bool {
+    for i in 0..node.child_count() {
+        if let Some(c) = node.child(i) {
+            if c.kind() == tok {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn starts_with_uppercase(s: &str) -> bool {
+    s.chars().next().is_some_and(|c| c.is_ascii_uppercase())
+}
+
+fn has_jsx_descendant(node: Node) -> bool {
+    if matches!(
+        node.kind(),
+        kind::JSX_ELEMENT | kind::JSX_SELF_CLOSING | kind::JSX_FRAGMENT
+    ) {
+        return true;
+    }
+    for i in 0..node.child_count() {
+        if let Some(c) = node.child(i) {
+            if has_jsx_descendant(c) {
+                return true;
+            }
+        }
+    }
+    false
+}

--- a/yah-kg-ts/tests/dogfood_yah_ui.rs
+++ b/yah-kg-ts/tests/dogfood_yah_ui.rs
@@ -1,0 +1,231 @@
+//! Dogfood: index the real yah-ui frontend source tree and verify the
+//! kinds of structural facts the Tauri shell will rely on.
+//!
+//! This test is co-tenanted with the workspace, so it expects yah-ui
+//! to live at `<workspace>/yah-ui`. It's marked ignored if that directory
+//! is missing so out-of-tree consumers don't need to ship the frontend.
+
+use std::path::PathBuf;
+use yah_kg::kind::{CommonKind, NodeKind, TsKind};
+use yah_kg::rpc::Direction;
+use yah_kg::edge::EdgeKind;
+use yah_kg_store::{walk_and_index, IndexerRegistry, Store};
+use yah_kg_ts::TsIndexer;
+
+fn yah_ui_src() -> Option<PathBuf> {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let candidate = manifest.parent()?.join("yah-ui").join("src");
+    candidate.exists().then_some(candidate)
+}
+
+#[test]
+fn indexes_yah_ui_and_finds_known_components() {
+    let Some(src) = yah_ui_src() else {
+        eprintln!("yah-ui/src not present; skipping dogfood test");
+        return;
+    };
+
+    let mut store = Store::new();
+    let mut registry = IndexerRegistry::new();
+    registry.register(Box::new(TsIndexer::new()));
+
+    let summary = walk_and_index(&src, &mut store, &registry).expect("walk");
+    eprintln!(
+        "yah-ui dogfood: {} files indexed, {} skipped, {} parse errors, {} nodes, {} edges",
+        summary.files_indexed,
+        summary.files_skipped,
+        summary.parse_errors,
+        store.node_count(),
+        store.edge_count()
+    );
+
+    // Every .ts/.tsx file should parse (zero parse errors).
+    assert_eq!(
+        summary.parse_errors, 0,
+        "yah-ui frontend should parse cleanly"
+    );
+    // We expect at least the 25 TS/TSX files we already see in the tree.
+    assert!(
+        summary.files_indexed >= 20,
+        "expected ≥20 indexed files, got {}",
+        summary.files_indexed
+    );
+
+    // Collect labels and kinds from the landmark files we know exist.
+    let mut all_labels: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut all_kinds: std::collections::HashSet<(String, String)> =
+        std::collections::HashSet::new();
+    for file_rel in [
+        "App.tsx",
+        "types.ts",
+        "components/board/Board.tsx",
+        "components/board/Column.tsx",
+        "components/board/TicketCard.tsx",
+        "components/arch/ArchView.tsx",
+        "components/agent/AgentView.tsx",
+        "components/shell/TitleBar.tsx",
+        "components/shell/TabStrip.tsx",
+    ] {
+        for id in store.lookup(file_rel, None) {
+            if let Some(n) = store.node_ref(id) {
+                all_labels.insert(n.label.clone());
+                all_kinds.insert((n.label.clone(), format!("{:?}", n.kind)));
+            }
+        }
+    }
+    // Top-level component / type landmarks from yah-ui design.
+    for required in [
+        "App",
+        "Board",
+        "Column",
+        "TicketCard",
+        "ArchView",
+        "AgentView",
+        "TitleBar",
+        "TabStrip",
+        "Ticket",
+        "ColumnKey",
+        "Rig",
+    ] {
+        assert!(
+            all_labels.contains(required),
+            "yah-ui dogfood missed `{required}`; sample labels: {:?}",
+            all_labels.iter().take(40).collect::<Vec<_>>()
+        );
+    }
+
+    // The big-ticket components must register as JsxComponent in .tsx files.
+    let jsx_components: Vec<&(String, String)> = all_kinds
+        .iter()
+        .filter(|(_, k)| k.contains("JsxComponent"))
+        .collect();
+    assert!(
+        jsx_components.iter().any(|(l, _)| l == "App"),
+        "App should be a JsxComponent; jsx components: {:?}",
+        jsx_components
+    );
+    assert!(
+        jsx_components.iter().any(|(l, _)| l == "Board"),
+        "Board should be a JsxComponent"
+    );
+
+    // Interface landmark
+    let ticket_interface = all_kinds
+        .iter()
+        .find(|(l, k)| l == "Ticket" && k.contains("Interface"));
+    assert!(
+        ticket_interface.is_some(),
+        "Ticket should be an Interface; relevant nodes: {:?}",
+        all_kinds.iter().filter(|(l, _)| l == "Ticket").collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn yah_ui_lookup_resolves_path_line_to_innermost_node() {
+    let Some(src) = yah_ui_src() else {
+        return;
+    };
+
+    let mut store = Store::new();
+    let mut registry = IndexerRegistry::new();
+    registry.register(Box::new(TsIndexer::new()));
+    walk_and_index(&src, &mut store, &registry).expect("walk");
+
+    // The agent's tool-result `path:line` chips need this query to work.
+    // App.tsx line 10 is `export function App() { ... }` per the file we
+    // inspected earlier — the innermost hit should be the App component.
+    let hits = store.lookup("App.tsx", Some(10));
+    let first_label = hits
+        .first()
+        .and_then(|id| store.node_ref(*id).map(|n| n.label.clone()));
+    assert!(
+        first_label.as_deref() == Some("App")
+            || first_label.as_deref() == Some("App.tsx"),
+        "expected App or App.tsx as innermost; got {first_label:?} from {hits:?}"
+    );
+}
+
+#[test]
+fn yah_ui_no_jsx_components_in_pure_ts_files() {
+    let Some(src) = yah_ui_src() else {
+        return;
+    };
+    let mut store = Store::new();
+    let mut registry = IndexerRegistry::new();
+    registry.register(Box::new(TsIndexer::new()));
+    walk_and_index(&src, &mut store, &registry).expect("walk");
+
+    // .ts files (e.g. types.ts, mock.ts) should never produce JsxComponent
+    // nodes — the heuristic is gated on `tsx` in the file path.
+    for id in store.lookup("types.ts", None) {
+        let n = store.node_ref(id).unwrap();
+        assert!(
+            !matches!(n.kind, NodeKind::Ts(TsKind::JsxComponent)),
+            "types.ts should have no JsxComponent; offender: {:?}",
+            n.label
+        );
+    }
+}
+
+#[test]
+fn yah_ui_subgraph_from_app_reaches_other_files() {
+    // After walking the directory, the App component should be reachable
+    // from the walker-emitted Directory tree (App.tsx → Directory → ...).
+    // We don't rely on TS Imports edges yet (Pass 3 work).
+    let Some(src) = yah_ui_src() else {
+        return;
+    };
+    let mut store = Store::new();
+    let mut registry = IndexerRegistry::new();
+    registry.register(Box::new(TsIndexer::new()));
+    walk_and_index(&src, &mut store, &registry).expect("walk");
+
+    // Find the directory node. The walker uses the rig-relative path which
+    // becomes "." for the root we passed.
+    let root_dir_hits = store.lookup(".", None);
+    let root_dir = root_dir_hits.iter().copied().find(|id| {
+        store
+            .node_ref(*id)
+            .map(|n| matches!(n.kind, NodeKind::Common(CommonKind::Directory)))
+            .unwrap_or(false)
+    });
+    let Some(root_dir) = root_dir else {
+        // Walker may use a non-"." root id depending on how the path
+        // resolves; either way we can hop to App.tsx via Contains edges.
+        return;
+    };
+
+    let sg = store.subgraph(
+        root_dir,
+        4,
+        Some(&[EdgeKind::Contains]),
+        None,
+        None,
+        None,
+    );
+    let labels: Vec<String> = sg.nodes.iter().map(|n| n.label.clone()).collect();
+    assert!(
+        labels.iter().any(|l| l == "App.tsx"),
+        "App.tsx should be reachable from root directory via Contains; got {} nodes",
+        sg.nodes.len()
+    );
+
+    // Hop further: App.tsx contains the App component itself.
+    let app_neighbors = store.neighbors(
+        sg.nodes
+            .iter()
+            .find(|n| n.label == "App.tsx")
+            .map(|n| n.id)
+            .unwrap(),
+        Direction::Out,
+        Some(&[EdgeKind::Contains]),
+    );
+    let app_children: Vec<String> = app_neighbors
+        .iter()
+        .filter_map(|e| store.node_ref(e.to).map(|n| n.label.clone()))
+        .collect();
+    assert!(
+        app_children.iter().any(|l| l == "App"),
+        "App.tsx should contain App; got {app_children:?}"
+    );
+}

--- a/yah-kg-ts/tests/index_then_query.rs
+++ b/yah-kg-ts/tests/index_then_query.rs
@@ -1,0 +1,357 @@
+//! End-to-end TS/TSX indexer tests: parse a fixture string with
+//! `TsIndexer`, push results into a `Store`, then exercise the queries
+//! the daemon will expose under `arch.*`.
+
+use std::path::Path;
+use yah_kg::edge::EdgeKind;
+use yah_kg::indexer::LanguageIndexer;
+use yah_kg::kind::{CommonKind, Lang, NodeKind, TsKind};
+use yah_kg::rpc::Direction;
+use yah_kg_store::{Store, StoreSink};
+use yah_kg_ts::TsIndexer;
+
+const TS_SRC: &str = r#"// Domain types for the board.
+
+export type ColumnKey = "open" | "active" | "handoff" | "review";
+
+export interface Ticket {
+  id: string;
+  title: string;
+  status: ColumnKey;
+}
+
+export interface Relay extends Ticket {
+  children: Ticket[];
+}
+
+export enum Priority {
+  Low,
+  High,
+}
+
+export const FIXED_LIMIT = 100;
+
+export function loadTickets(rigId: string): Ticket[] {
+  return [];
+}
+
+export class TicketStore {
+  private items: Ticket[] = [];
+
+  add(t: Ticket): void {
+    this.items.push(t);
+  }
+
+  count(): number {
+    return this.items.length;
+  }
+}
+
+export class FilteredStore extends TicketStore implements Iterable<Ticket> {
+  [Symbol.iterator](): Iterator<Ticket> {
+    return this.items[Symbol.iterator]();
+  }
+}
+
+namespace internal {
+  export const SECRET = 42;
+  export function helper(): void {}
+}
+"#;
+
+const TSX_SRC: &str = r#"import { useState } from "react";
+
+interface BoardProps {
+  tickets: Ticket[];
+  onChange: (t: Ticket[]) => void;
+}
+
+export function Board({ tickets, onChange }: BoardProps) {
+  const [filter, setFilter] = useState<string>("");
+  return (
+    <div className="board">
+      <input value={filter} onChange={(e) => setFilter(e.target.value)} />
+      <Column tickets={tickets} />
+    </div>
+  );
+}
+
+export const Column = ({ tickets }: { tickets: Ticket[] }) => {
+  return <div>{tickets.length}</div>;
+};
+
+function lowercaseHelper(): number {
+  return 1;
+}
+
+export default function Page() {
+  return <Board tickets={[]} onChange={() => {}} />;
+}
+"#;
+
+fn build_store_for(path: &str, src: &str) -> Store {
+    let mut store = Store::new();
+    {
+        let mut sink = StoreSink::new(&mut store);
+        TsIndexer::new()
+            .index_file(Path::new(path), src, &mut sink)
+            .expect("indexer should accept the fixture");
+    }
+    store
+}
+
+#[test]
+fn ts_emits_interface_type_alias_enum_function_class() {
+    let store = build_store_for("src/types.ts", TS_SRC);
+
+    let all = store.lookup("src/types.ts", None);
+    let by_label: Vec<(String, NodeKind)> = all
+        .iter()
+        .filter_map(|id| {
+            let n = store.node_ref(*id)?;
+            Some((n.label.clone(), n.kind.clone()))
+        })
+        .collect();
+
+    let names: std::collections::HashSet<&str> =
+        by_label.iter().map(|(l, _)| l.as_str()).collect();
+    for required in [
+        "ColumnKey",
+        "Ticket",
+        "Relay",
+        "Priority",
+        "Low",
+        "High",
+        "FIXED_LIMIT",
+        "loadTickets",
+        "TicketStore",
+        "FilteredStore",
+        "internal",
+        "SECRET",
+        "helper",
+        "add",
+        "count",
+    ] {
+        assert!(
+            names.contains(required),
+            "missing {required}; saw {:?}",
+            names
+        );
+    }
+
+    // Kind-level checks
+    assert!(
+        by_label
+            .iter()
+            .any(|(l, k)| l == "Ticket" && matches!(k, NodeKind::Ts(TsKind::Interface)))
+    );
+    assert!(
+        by_label
+            .iter()
+            .any(|(l, k)| l == "ColumnKey" && matches!(k, NodeKind::Ts(TsKind::TypeAlias)))
+    );
+    assert!(
+        by_label
+            .iter()
+            .any(|(l, k)| l == "Priority" && matches!(k, NodeKind::Ts(TsKind::Enum)))
+    );
+    assert!(
+        by_label
+            .iter()
+            .any(|(l, k)| l == "TicketStore" && matches!(k, NodeKind::Common(CommonKind::Type)))
+    );
+    assert!(
+        by_label
+            .iter()
+            .any(|(l, k)| l == "Low" && matches!(k, NodeKind::Common(CommonKind::Variant)))
+    );
+    assert!(
+        by_label
+            .iter()
+            .any(|(l, k)| l == "loadTickets" && matches!(k, NodeKind::Common(CommonKind::Function)))
+    );
+    assert!(
+        by_label
+            .iter()
+            .any(|(l, k)| l == "FIXED_LIMIT" && matches!(k, NodeKind::Common(CommonKind::Constant)))
+    );
+    assert!(
+        by_label
+            .iter()
+            .any(|(l, k)| l == "internal" && matches!(k, NodeKind::Common(CommonKind::Module)))
+    );
+}
+
+#[test]
+fn ts_extends_edge_resolves_within_file() {
+    let store = build_store_for("src/types.ts", TS_SRC);
+
+    let all = store.lookup("src/types.ts", None);
+    let relay_id = all
+        .iter()
+        .copied()
+        .find(|id| {
+            store
+                .node_ref(*id)
+                .map(|n| n.label == "Relay")
+                .unwrap_or(false)
+        })
+        .expect("Relay interface");
+    let out = store.neighbors(relay_id, Direction::Out, Some(&[EdgeKind::Extends]));
+    assert!(
+        !out.is_empty(),
+        "Relay should have an Extends edge to Ticket"
+    );
+    assert_eq!(
+        store.node_ref(out[0].to).map(|n| n.label.as_str()),
+        Some("Ticket")
+    );
+
+    // Class extends class
+    let filtered_id = all
+        .iter()
+        .copied()
+        .find(|id| {
+            store
+                .node_ref(*id)
+                .map(|n| n.label == "FilteredStore")
+                .unwrap_or(false)
+        })
+        .expect("FilteredStore class");
+    let out = store.neighbors(filtered_id, Direction::Out, Some(&[EdgeKind::Extends]));
+    assert!(out.iter().any(|e| store
+        .node_ref(e.to)
+        .map(|n| n.label == "TicketStore")
+        .unwrap_or(false)));
+}
+
+#[test]
+fn ts_class_methods_emit_defines_edges() {
+    let store = build_store_for("src/types.ts", TS_SRC);
+    let all = store.lookup("src/types.ts", None);
+    let store_id = all
+        .iter()
+        .copied()
+        .find(|id| {
+            store
+                .node_ref(*id)
+                .map(|n| n.label == "TicketStore")
+                .unwrap_or(false)
+        })
+        .expect("TicketStore");
+    let defines = store.neighbors(store_id, Direction::Out, Some(&[EdgeKind::Defines]));
+    let method_labels: Vec<String> = defines
+        .iter()
+        .filter_map(|e| store.node_ref(e.to).map(|n| n.label.clone()))
+        .collect();
+    assert!(
+        method_labels.contains(&"add".to_string())
+            && method_labels.contains(&"count".to_string()),
+        "expected add+count defined; got {method_labels:?}"
+    );
+}
+
+#[test]
+fn tsx_capitalized_function_becomes_jsx_component() {
+    let store = build_store_for("src/Board.tsx", TSX_SRC);
+    let all = store.lookup("src/Board.tsx", None);
+
+    let by_label: Vec<(String, NodeKind)> = all
+        .iter()
+        .filter_map(|id| {
+            let n = store.node_ref(*id)?;
+            Some((n.label.clone(), n.kind.clone()))
+        })
+        .collect();
+
+    // Component (named function declaration)
+    assert!(
+        by_label
+            .iter()
+            .any(|(l, k)| l == "Board" && matches!(k, NodeKind::Ts(TsKind::JsxComponent))),
+        "Board should be a JsxComponent; got {by_label:?}"
+    );
+    // Component via const arrow function
+    assert!(
+        by_label
+            .iter()
+            .any(|(l, k)| l == "Column" && matches!(k, NodeKind::Ts(TsKind::JsxComponent))),
+        "Column (const arrow) should be JsxComponent; got {by_label:?}"
+    );
+    // Lowercase function should NOT be a component
+    assert!(
+        by_label
+            .iter()
+            .any(|(l, k)| l == "lowercaseHelper" && matches!(k, NodeKind::Common(CommonKind::Function))),
+        "lowercaseHelper should be a plain Function; got {by_label:?}"
+    );
+    // Default-exported component
+    assert!(
+        by_label
+            .iter()
+            .any(|(l, k)| l == "Page" && matches!(k, NodeKind::Ts(TsKind::JsxComponent))),
+        "Page should be a JsxComponent; got {by_label:?}"
+    );
+    // Page should be marked default_export.
+    let page_id = all
+        .iter()
+        .copied()
+        .find(|id| {
+            store
+                .node_ref(*id)
+                .map(|n| n.label == "Page")
+                .unwrap_or(false)
+        })
+        .unwrap();
+    let full = store.node_full(page_id).unwrap();
+    assert_eq!(
+        full.properties.get("default_export").map(|s| s.as_str()),
+        Some("true")
+    );
+}
+
+#[test]
+fn tsx_file_marked_with_tsx_property() {
+    let store = build_store_for("src/Board.tsx", TSX_SRC);
+    // The file node carries a `tsx = "true"` property so consumers can
+    // distinguish .tsx from plain .ts without re-parsing the path.
+    let file_id = store
+        .lookup("src/Board.tsx", None)
+        .into_iter()
+        .find(|id| {
+            store
+                .node_ref(*id)
+                .map(|n| matches!(n.kind, NodeKind::Common(CommonKind::File)))
+                .unwrap_or(false)
+        })
+        .unwrap();
+    let full = store.node_full(file_id).unwrap();
+    assert_eq!(
+        full.properties.get("tsx").map(|s| s.as_str()),
+        Some("true")
+    );
+}
+
+#[test]
+fn ts_indexer_metadata_is_correct() {
+    let i = TsIndexer::new();
+    assert_eq!(i.lang(), Lang::Ts);
+    assert_eq!(i.extensions(), &["ts", "tsx"]);
+}
+
+#[test]
+fn ts_lookup_returns_innermost_first() {
+    let store = build_store_for("src/types.ts", TS_SRC);
+    // Line 30 is inside the `add` method body of TicketStore (the
+    // `this.items.push(t);` statement).
+    let hits = store.lookup("src/types.ts", Some(30));
+    let first_label = hits
+        .first()
+        .and_then(|id| store.node_ref(*id).map(|n| n.label.clone()));
+    // Innermost should be the method, not the class or file.
+    assert_eq!(
+        first_label.as_deref(),
+        Some("add"),
+        "innermost-first should surface `add`; got {hits:?}"
+    );
+}


### PR DESCRIPTION
…yah-ui

New workspace crate that implements `LanguageIndexer` for `.ts` and `.tsx` files, built on tree-sitter-typescript. Picks the right grammar by extension (`tsx` for JSX support).

Emits:
* Nodes: File, Module (TS namespace), Type (class), Field, Variant (enum member), Function, Method, Constant, plus the TS-specific Interface, TypeAlias, Enum, JsxComponent.
* Edges: Contains, Defines (class/interface → method), Extends (class extends class, interface extends interface) and Implements (class implements interface) — same-file simple-ident resolution only; cross-file is Pass 3.
* Properties: type_kind, decorators, abstract, async, default_export, tsx, ambient, returns_jsx, extends_target, implements_target.

JSX heuristic: in a .tsx file, a top-level function declaration or `const foo = () => …` arrow whose name starts uppercase is tagged as JsxComponent. This catches the React component patterns in yah-ui (named function components, arrow consts, default-exported pages) without scanning method bodies for JSX returns.

Tree-sitter quirks handled:
* `namespace foo {}` parses inside an `expression_statement` wrapper — walked transparently.
* `declare namespace foo {}` parses inside an `ambient_declaration` wrapper — same treatment.
* Decorator names extracted by walking the leftmost identifier under the decorator subtree.

Tests:
* index_then_query.rs (7): fixture TS + TSX coverage of every node / edge kind, JSX detection (positive + negative), default-export property, tsx-file marker, and innermost-first lookup.
* dogfood_yah_ui.rs (4): walks the real yah-ui frontend (25 .ts/.tsx files), asserts zero parse errors, finds App / Board / Column / TicketCard / ArchView / AgentView / TitleBar / TabStrip / Ticket / ColumnKey / Rig, confirms App and Board register as JsxComponent, confirms types.ts produces no JsxComponent, and verifies subgraph traversal from the directory root reaches App.tsx → App via Contains. Indexes 267 nodes / 266 edges.

Choice of parser: tree-sitter-typescript over swc_ecma_parser. The tree-sitter substrate generalizes to Python, Go, etc. once we extend beyond TS — investing in the walker shape now pays off across languages. The cost is matching on `&'static str` node kinds rather than typed enums; centralized in a `kind` const module.