### PR TITLE
yah-kg-daemon: runtime composition with file watcher + event bus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,12 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
@@ -323,6 +329,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -487,6 +502,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
+dependencies = [
+ "bitflags 2.10.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,6 +544,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -526,7 +581,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "libc",
 ]
 
@@ -573,8 +628,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.10.0",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -698,7 +781,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -747,7 +830,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1484,6 +1567,21 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "yah-kg-daemon"
+version = "0.6.0"
+dependencies = [
+ "notify",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "yah-kg",
+ "yah-kg-rust",
+ "yah-kg-store",
+ "yah-kg-ts",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "yah-kg-store",
     "yah-kg-rust",
     "yah-kg-ts",
+    "yah-kg-daemon",
 ]
 resolver = "2"
 

--- a/yah-kg-daemon/Cargo.toml
+++ b/yah-kg-daemon/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "yah-kg-daemon"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Runtime composition of the yah knowledge-graph: store + watcher + event bus, exposing the arch.* surface as in-process Rust calls"
+
+[dependencies]
+yah-kg = { path = "../yah-kg" }
+yah-kg-store = { path = "../yah-kg-store" }
+notify = "8.2"
+tokio = { version = "1", features = ["sync", "rt", "rt-multi-thread", "macros", "time"] }
+thiserror = "1.0"
+tracing = "0.1"
+
+[dev-dependencies]
+yah-kg-rust = { path = "../yah-kg-rust" }
+yah-kg-ts = { path = "../yah-kg-ts" }
+tempfile = "3"
+tokio = { version = "1", features = ["sync", "rt", "rt-multi-thread", "macros", "time", "test-util"] }

--- a/yah-kg-daemon/src/lib.rs
+++ b/yah-kg-daemon/src/lib.rs
@@ -1,0 +1,29 @@
+//! @arch:layer(kg_store)
+//! @arch:role(graph)
+//!
+//! `yah-kg-daemon` — runtime composition of the knowledge graph.
+//!
+//! Wraps a [`yah_kg_store::Store`] in a `tokio::sync::RwLock`, owns an
+//! [`yah_kg_store::IndexerRegistry`], runs a `notify` file watcher, and
+//! fans `ArchEvent`s out over a `tokio::sync::broadcast` channel.
+//!
+//! Exposes the `arch.*` RPC surface as in-process async methods so Tauri
+//! commands can call them directly. JSON-RPC framing for remote/browser
+//! transports lives downstream — this crate is transport-agnostic.
+//!
+//! Concurrency model:
+//! * One `Store` behind `RwLock`. Queries take read locks (cheap, parallel);
+//!   reindex paths take write locks for the snapshot/wipe/re-emit cycle.
+//! * Watcher events arrive on a `notify` callback running on its own
+//!   thread; we forward them through an `mpsc` channel to a tokio task
+//!   that does the reindex on the runtime.
+//! * `ArchEvent` is a `tokio::sync::broadcast` so any number of subscribers
+//!   (Tauri command, JSON-RPC fanout, internal listeners) can tail without
+//!   blocking each other.
+
+pub mod path;
+pub mod service;
+pub mod watcher;
+
+pub use service::{DaemonError, KgService, ServiceConfig};
+pub use watcher::{WatcherHandle, WatcherKind};

--- a/yah-kg-daemon/src/path.rs
+++ b/yah-kg-daemon/src/path.rs
@@ -1,0 +1,43 @@
+//! @arch:layer(kg_store)
+//! @arch:role(graph)
+//!
+//! Path utilities. The store keys nodes by *rig-relative* paths with
+//! forward slashes; the watcher and Tauri commands hand us *absolute*
+//! paths off the host filesystem. This module is the canonical place
+//! to canonicalize the rig root and translate between the two.
+
+use std::path::{Path, PathBuf};
+
+/// Canonicalize the rig root, falling back to the input on failure.
+pub fn canonicalize_root(root: &Path) -> PathBuf {
+    root.canonicalize().unwrap_or_else(|_| root.to_path_buf())
+}
+
+/// Convert an absolute path to a rig-relative `String` with forward
+/// slashes. Returns `None` if the path is outside the rig root.
+pub fn relativize(path: &Path, root: &Path) -> Option<String> {
+    let canon_path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    let stripped = canon_path.strip_prefix(root).ok()?;
+    Some(stripped.to_string_lossy().replace('\\', "/"))
+}
+
+/// `true` when the path looks like one we should be reindexing — has an
+/// extension and isn't inside a skipped directory (`target/`, `.git/`,
+/// `node_modules/`).
+pub fn is_eligible(path: &Path) -> bool {
+    if path.extension().is_none() {
+        return false;
+    }
+    for component in path.components() {
+        let Some(s) = component.as_os_str().to_str() else {
+            continue;
+        };
+        if matches!(s, "target" | ".git" | "node_modules") {
+            return false;
+        }
+        if s.starts_with('.') && s != "." && s != ".." {
+            return false;
+        }
+    }
+    true
+}

--- a/yah-kg-daemon/src/service.rs
+++ b/yah-kg-daemon/src/service.rs
@@ -1,0 +1,441 @@
+//! @arch:layer(kg_store)
+//! @arch:role(graph)
+//!
+//! `KgService` — the daemon's primary handle.
+//!
+//! Construction is synchronous (no I/O, no tasks). The service starts cold
+//! and is brought online by [`KgService::boot`], which walks the rig and
+//! populates the store. Watching is opt-in via
+//! [`KgService::start_watching`].
+//!
+//! Method shapes mirror the `arch.*` RPC surface in `yah_kg::rpc`.
+
+use crate::path::{canonicalize_root, is_eligible, relativize};
+use crate::watcher::{spawn_watcher, WatcherHandle, WatcherKind};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Instant;
+use tokio::sync::{broadcast, RwLock};
+use yah_kg::event::{ArchEvent, IndexReason, IndexScope};
+use yah_kg::ids::{NodeFull, NodeId};
+use yah_kg::indexer::IndexError;
+use yah_kg::kind::Lang;
+use yah_kg::rpc::{
+    LookupParams, LookupResult, NeighborsParams, NeighborsResult, RootsParams, RootsResult,
+    StatsResult, Subgraph, SubgraphParams,
+};
+use yah_kg_store::{reindex_file, walk_and_index, IndexerRegistry, Store, WalkSummary};
+
+#[derive(Debug, thiserror::Error)]
+pub enum DaemonError {
+    #[error("daemon not booted — call boot(rig_root) first")]
+    NotBooted,
+    #[error("indexer error: {0}")]
+    Index(#[from] IndexError),
+    #[error("watcher error: {0}")]
+    Watcher(String),
+    #[error("io error: {0}")]
+    Io(String),
+}
+
+/// Tunable knobs. Defaults are sensible for an interactive Tauri host.
+#[derive(Debug, Clone)]
+pub struct ServiceConfig {
+    /// Capacity of the broadcast channel. Slow subscribers that fall behind
+    /// will see `RecvError::Lagged` rather than back-pressuring publishers.
+    pub event_capacity: usize,
+    /// Default `node_limit` for `subgraph` queries when the caller doesn't
+    /// supply one.
+    pub default_subgraph_limit: u32,
+}
+
+impl Default for ServiceConfig {
+    fn default() -> Self {
+        Self {
+            event_capacity: 1024,
+            default_subgraph_limit: 2_000,
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+struct Booted {
+    rig_root: PathBuf,
+    last_index_ms: Option<u64>,
+}
+
+pub struct KgService {
+    store: Arc<RwLock<Store>>,
+    registry: Arc<IndexerRegistry>,
+    events: broadcast::Sender<ArchEvent>,
+    booted: Arc<RwLock<Option<Booted>>>,
+    watcher: Arc<RwLock<Option<WatcherHandle>>>,
+    config: ServiceConfig,
+}
+
+impl KgService {
+    pub fn new(registry: IndexerRegistry) -> Self {
+        Self::with_config(registry, ServiceConfig::default())
+    }
+
+    pub fn with_config(registry: IndexerRegistry, config: ServiceConfig) -> Self {
+        let (events, _) = broadcast::channel(config.event_capacity);
+        Self {
+            store: Arc::new(RwLock::new(Store::new())),
+            registry: Arc::new(registry),
+            events,
+            booted: Arc::new(RwLock::new(None)),
+            watcher: Arc::new(RwLock::new(None)),
+            config,
+        }
+    }
+
+    /// Languages for which the daemon has a registered indexer. Mirrors
+    /// the `arch.languages` RPC.
+    pub fn languages(&self) -> Vec<Lang> {
+        self.registry.languages()
+    }
+
+    /// Subscribe to the `ArchEvent` stream. Each subscriber gets its own
+    /// receiver; events fan out. Drop the receiver to unsubscribe.
+    pub fn subscribe(&self) -> broadcast::Receiver<ArchEvent> {
+        self.events.subscribe()
+    }
+
+    /// Cold-start: walk `rig_root` and populate the store. Idempotent —
+    /// calling it again rebinds to the new root and emits an
+    /// `IndexFinished` event.
+    pub async fn boot(&self, rig_root: PathBuf) -> Result<WalkSummary, DaemonError> {
+        let canon = canonicalize_root(&rig_root);
+        self.send(ArchEvent::IndexStarted {
+            reason: IndexReason::Boot,
+            scope: IndexScope::All,
+        });
+
+        let start = Instant::now();
+        let summary = {
+            let mut store = self.store.write().await;
+            // Wipe existing nodes before booting against a new rig.
+            *store = Store::new();
+            walk_and_index(&canon, &mut store, &self.registry)
+                .map_err(DaemonError::Index)?
+        };
+        let elapsed = start.elapsed().as_millis() as u64;
+
+        {
+            let mut booted = self.booted.write().await;
+            *booted = Some(Booted {
+                rig_root: canon,
+                last_index_ms: Some(elapsed),
+            });
+        }
+
+        self.send(ArchEvent::IndexFinished {
+            duration_ms: elapsed,
+            nodes_added: summary.files_indexed, // placeholder counts; full diff comes from reindex_path
+            nodes_changed: 0,
+            nodes_removed: 0,
+            edges_added: 0,
+            edges_removed: 0,
+        });
+        Ok(summary)
+    }
+
+    /// Start a `notify` watcher rooted at the booted rig. No-op if a
+    /// watcher is already running.
+    pub async fn start_watching(&self) -> Result<(), DaemonError> {
+        let rig_root = self.rig_root().await?;
+
+        let mut slot = self.watcher.write().await;
+        if slot.is_some() {
+            return Ok(());
+        }
+
+        let store = Arc::clone(&self.store);
+        let registry = Arc::clone(&self.registry);
+        let events = self.events.clone();
+        let root_for_task = rig_root.clone();
+
+        let handle = spawn_watcher(
+            WatcherKind::Recursive,
+            rig_root.clone(),
+            move |abs_paths| {
+                let store = Arc::clone(&store);
+                let registry = Arc::clone(&registry);
+                let events = events.clone();
+                let root = root_for_task.clone();
+                Box::pin(async move {
+                    apply_paths(abs_paths, &root, &store, &registry, &events).await;
+                })
+            },
+        )
+        .await
+        .map_err(|e| DaemonError::Watcher(e.to_string()))?;
+
+        *slot = Some(handle);
+        Ok(())
+    }
+
+    /// Stop the watcher if running. Idempotent.
+    pub async fn stop_watching(&self) {
+        let mut slot = self.watcher.write().await;
+        if let Some(handle) = slot.take() {
+            handle.stop().await;
+        }
+    }
+
+    /// Manual reindex of one absolute path. Most callers use the watcher;
+    /// this is the entry point pi-mono will call after an agent edit so
+    /// the resulting `ArchEvent`s carry `IndexReason::AgentEdit`.
+    pub async fn reindex_path(
+        &self,
+        abs_path: &Path,
+        reason: IndexReason,
+    ) -> Result<(), DaemonError> {
+        let rig_root = self.rig_root().await?;
+        let Some(rel) = relativize(abs_path, &rig_root) else {
+            return Ok(());
+        };
+        if !is_eligible(Path::new(&rel)) {
+            return Ok(());
+        }
+
+        self.send(ArchEvent::IndexStarted {
+            reason,
+            scope: IndexScope::Files {
+                paths: vec![rel.clone()],
+            },
+        });
+        let start = Instant::now();
+
+        let delta = {
+            let mut store = self.store.write().await;
+            reindex_file(&rig_root, &rel, &mut store, &self.registry)
+                .map_err(DaemonError::Index)?
+        };
+
+        emit_delta(&self.events, &delta);
+
+        self.send(ArchEvent::IndexFinished {
+            duration_ms: start.elapsed().as_millis() as u64,
+            nodes_added: delta.nodes_added.len() as u32,
+            nodes_changed: delta.nodes_changed.len() as u32,
+            nodes_removed: delta.nodes_removed.len() as u32,
+            edges_added: delta.edges_added.len() as u32,
+            edges_removed: delta.edges_removed.len() as u32,
+        });
+
+        if let Some(booted) = self.booted.write().await.as_mut() {
+            booted.last_index_ms = Some(start.elapsed().as_millis() as u64);
+        }
+        Ok(())
+    }
+
+    /// Emit an `AgentTouch` event: pi-mono ran a tool over `paths` (with
+    /// optional `:line` suffixes) and we resolve those to NodeIds via the
+    /// store's lookup index. Subscribers (the UI) candle-pulse the touched
+    /// nodes.
+    pub async fn touch(&self, paths: &[String], tool: &str, relay: &str) {
+        let store = self.store.read().await;
+        let mut ids: Vec<NodeId> = Vec::new();
+        for p in paths {
+            let (file, line) = parse_path_line(p);
+            for id in store.lookup(file, line) {
+                ids.push(id);
+            }
+        }
+        drop(store);
+        if ids.is_empty() {
+            return;
+        }
+        self.send(ArchEvent::AgentTouch {
+            ids,
+            tool: tool.to_string(),
+            relay: relay.to_string(),
+            ts: now_ms(),
+        });
+    }
+
+    // ---------- Read queries (mirror arch.* RPC) ----------
+
+    pub async fn subgraph(&self, params: SubgraphParams) -> Subgraph {
+        let store = self.store.read().await;
+        store.subgraph(
+            params.root,
+            params.depth,
+            params.edges.as_deref(),
+            params.kinds.as_deref(),
+            params.langs.as_deref(),
+            Some(
+                params
+                    .node_limit
+                    .unwrap_or(self.config.default_subgraph_limit),
+            ),
+        )
+    }
+
+    pub async fn lookup(&self, params: LookupParams) -> LookupResult {
+        let store = self.store.read().await;
+        LookupResult {
+            ids: store.lookup(&params.file, params.line),
+        }
+    }
+
+    pub async fn node(&self, id: NodeId) -> Option<NodeFull> {
+        let store = self.store.read().await;
+        store.node_full(id)
+    }
+
+    pub async fn neighbors(&self, params: NeighborsParams) -> NeighborsResult {
+        let store = self.store.read().await;
+        NeighborsResult {
+            edges: store.neighbors(params.id, params.dir, params.edges.as_deref()),
+        }
+    }
+
+    pub async fn roots(&self, params: RootsParams) -> RootsResult {
+        let store = self.store.read().await;
+        let langs = params.lang.as_ref().map(|l| vec![*l]);
+        let kinds = params.kind.clone().map(|k| vec![k]);
+        RootsResult {
+            roots: store.roots(langs.as_deref(), kinds.as_deref()),
+        }
+    }
+
+    pub async fn stats(&self) -> StatsResult {
+        let store = self.store.read().await;
+        let s = store.stats();
+        let last_index_ms = self
+            .booted
+            .read()
+            .await
+            .as_ref()
+            .and_then(|b| b.last_index_ms);
+        StatsResult {
+            node_count: s.node_count,
+            edge_count: s.edge_count,
+            by_lang: s.by_lang,
+            by_kind: s.by_kind,
+            last_index_ms,
+        }
+    }
+
+    // ---------- helpers ----------
+
+    async fn rig_root(&self) -> Result<PathBuf, DaemonError> {
+        self.booted
+            .read()
+            .await
+            .as_ref()
+            .map(|b| b.rig_root.clone())
+            .ok_or(DaemonError::NotBooted)
+    }
+
+    fn send(&self, event: ArchEvent) {
+        // Ignore the count — broadcast::send only fails if there are zero
+        // subscribers, which is fine in tests and in cold-start.
+        let _ = self.events.send(event);
+    }
+}
+
+fn emit_delta(events: &broadcast::Sender<ArchEvent>, delta: &yah_kg_store::FileDelta) {
+    for node in &delta.nodes_added {
+        let _ = events.send(ArchEvent::NodeAdded { node: node.clone() });
+    }
+    for (id, fields) in &delta.nodes_changed {
+        let _ = events.send(ArchEvent::NodeChanged {
+            id: *id,
+            fields: fields.clone(),
+        });
+    }
+    for id in &delta.nodes_removed {
+        let _ = events.send(ArchEvent::NodeRemoved { id: *id });
+    }
+    for edge in &delta.edges_added {
+        let _ = events.send(ArchEvent::EdgeAdded { edge: edge.clone() });
+    }
+    for id in &delta.edges_removed {
+        let _ = events.send(ArchEvent::EdgeRemoved { id: *id });
+    }
+}
+
+async fn apply_paths(
+    abs_paths: Vec<PathBuf>,
+    rig_root: &Path,
+    store: &Arc<RwLock<Store>>,
+    registry: &Arc<IndexerRegistry>,
+    events: &broadcast::Sender<ArchEvent>,
+) {
+    if abs_paths.is_empty() {
+        return;
+    }
+    // Resolve to rig-relative paths up front so we hold the lock briefly.
+    let mut rels: Vec<String> = Vec::new();
+    for p in abs_paths {
+        let Some(rel) = relativize(&p, rig_root) else {
+            continue;
+        };
+        if !is_eligible(Path::new(&rel)) {
+            continue;
+        }
+        rels.push(rel);
+    }
+    rels.sort();
+    rels.dedup();
+    if rels.is_empty() {
+        return;
+    }
+
+    let _ = events.send(ArchEvent::IndexStarted {
+        reason: IndexReason::FileWatch,
+        scope: IndexScope::Files {
+            paths: rels.clone(),
+        },
+    });
+
+    let start = Instant::now();
+    let mut totals = (0u32, 0u32, 0u32, 0u32, 0u32);
+    for rel in &rels {
+        let mut s = store.write().await;
+        match reindex_file(rig_root, rel, &mut s, registry) {
+            Ok(delta) => {
+                drop(s);
+                totals.0 += delta.nodes_added.len() as u32;
+                totals.1 += delta.nodes_changed.len() as u32;
+                totals.2 += delta.nodes_removed.len() as u32;
+                totals.3 += delta.edges_added.len() as u32;
+                totals.4 += delta.edges_removed.len() as u32;
+                emit_delta(events, &delta);
+            }
+            Err(e) => {
+                tracing::warn!(?rel, error = %e, "reindex failed");
+            }
+        }
+    }
+    let _ = events.send(ArchEvent::IndexFinished {
+        duration_ms: start.elapsed().as_millis() as u64,
+        nodes_added: totals.0,
+        nodes_changed: totals.1,
+        nodes_removed: totals.2,
+        edges_added: totals.3,
+        edges_removed: totals.4,
+    });
+}
+
+fn parse_path_line(s: &str) -> (&str, Option<u32>) {
+    if let Some((file, line)) = s.rsplit_once(':') {
+        if let Ok(n) = line.parse::<u32>() {
+            return (file, Some(n));
+        }
+    }
+    (s, None)
+}
+
+fn now_ms() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+

--- a/yah-kg-daemon/src/watcher.rs
+++ b/yah-kg-daemon/src/watcher.rs
@@ -1,0 +1,137 @@
+//! @arch:layer(kg_store)
+//! @arch:role(graph)
+//!
+//! `notify`-driven file watcher.
+//!
+//! `notify`'s callback runs on its own OS thread; we forward events through
+//! a `tokio::sync::mpsc` channel to a runtime task that debounces and calls
+//! the user-provided handler. Debouncing is a flat 50 ms window: editors
+//! typically emit several events per save (rename → write → chmod), and a
+//! short coalesce keeps us from reindexing the same file three times.
+
+use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use std::collections::HashSet;
+use std::future::Future;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::time::Duration;
+use tokio::sync::{mpsc, oneshot};
+
+const DEBOUNCE_MS: u64 = 50;
+
+#[derive(Debug, Clone, Copy)]
+pub enum WatcherKind {
+    Recursive,
+}
+
+impl From<WatcherKind> for RecursiveMode {
+    fn from(k: WatcherKind) -> Self {
+        match k {
+            WatcherKind::Recursive => RecursiveMode::Recursive,
+        }
+    }
+}
+
+pub struct WatcherHandle {
+    stop: Option<oneshot::Sender<()>>,
+    /// Hold the underlying watcher alive for the lifetime of the handle.
+    /// `notify` stops watching when the watcher value is dropped.
+    _watcher: RecommendedWatcher,
+}
+
+impl WatcherHandle {
+    /// Stop the watcher loop. Idempotent.
+    pub async fn stop(mut self) {
+        if let Some(tx) = self.stop.take() {
+            let _ = tx.send(());
+        }
+    }
+}
+
+type Handler = Box<
+    dyn Fn(Vec<PathBuf>) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>
+        + Send
+        + Sync
+        + 'static,
+>;
+
+/// Spawn a watcher rooted at `root` that calls `handler` with a deduped
+/// batch of changed paths.
+pub async fn spawn_watcher<F, Fut>(
+    kind: WatcherKind,
+    root: PathBuf,
+    handler: F,
+) -> Result<WatcherHandle, notify::Error>
+where
+    F: Fn(Vec<PathBuf>) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = ()> + Send + 'static,
+{
+    let handler: Handler = Box::new(move |paths| Box::pin(handler(paths)));
+
+    let (event_tx, mut event_rx) = mpsc::unbounded_channel::<Event>();
+    let mut watcher = notify::recommended_watcher(move |res: notify::Result<Event>| {
+        if let Ok(ev) = res {
+            let _ = event_tx.send(ev);
+        }
+    })?;
+    watcher.watch(&root, kind.into())?;
+
+    let (stop_tx, mut stop_rx) = oneshot::channel::<()>();
+
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                biased;
+                _ = &mut stop_rx => break,
+                event = event_rx.recv() => {
+                    let Some(first) = event else { break };
+                    // Pull more events that arrive within the debounce window.
+                    let mut batch: HashSet<PathBuf> = HashSet::new();
+                    if is_actionable(&first) {
+                        for p in &first.paths { batch.insert(p.clone()); }
+                    }
+                    let deadline = tokio::time::Instant::now()
+                        + Duration::from_millis(DEBOUNCE_MS);
+                    loop {
+                        let timeout = deadline.saturating_duration_since(
+                            tokio::time::Instant::now(),
+                        );
+                        if timeout.is_zero() { break; }
+                        match tokio::time::timeout(timeout, event_rx.recv()).await {
+                            Ok(Some(ev)) => {
+                                if is_actionable(&ev) {
+                                    for p in &ev.paths { batch.insert(p.clone()); }
+                                }
+                            }
+                            Ok(None) | Err(_) => break,
+                        }
+                    }
+                    if !batch.is_empty() {
+                        let paths: Vec<PathBuf> = batch.into_iter().collect();
+                        handler(paths).await;
+                    }
+                }
+            }
+        }
+    });
+
+    Ok(WatcherHandle {
+        stop: Some(stop_tx),
+        _watcher: watcher,
+    })
+}
+
+fn is_actionable(ev: &Event) -> bool {
+    matches!(
+        ev.kind,
+        EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
+    )
+}
+
+/// Test-only helper: check whether a path's extension would be picked up by
+/// any registered indexer. Not used by the daemon at runtime — the registry
+/// makes that determination on dispatch.
+#[doc(hidden)]
+pub fn _path_has_extension(p: &Path) -> bool {
+    p.extension().is_some()
+}

--- a/yah-kg-daemon/tests/e2e.rs
+++ b/yah-kg-daemon/tests/e2e.rs
@@ -1,0 +1,360 @@
+//! End-to-end daemon tests.
+//!
+//! Each test stands up a `KgService` against a tempdir, optionally starts
+//! a watcher, then exercises the `arch.*` surface against in-memory state.
+//! Watcher tests have generous timeouts to absorb filesystem-event jitter
+//! across hosts; if a test hangs, the timeout fires rather than leaving
+//! the suite stuck.
+
+use std::fs;
+use std::path::PathBuf;
+use std::time::Duration;
+use tempfile::TempDir;
+use tokio::sync::broadcast::error::RecvError;
+use tokio::time::timeout;
+use yah_kg::event::{ArchEvent, IndexReason};
+use yah_kg::kind::{CommonKind, Lang, NodeKind};
+use yah_kg::rpc::{LookupParams, RootsParams, SubgraphParams};
+use yah_kg_daemon::{DaemonError, KgService};
+use yah_kg_rust::RustIndexer;
+use yah_kg_store::IndexerRegistry;
+use yah_kg_ts::TsIndexer;
+
+const TIMEOUT: Duration = Duration::from_secs(5);
+
+fn registry() -> IndexerRegistry {
+    let mut r = IndexerRegistry::new();
+    r.register(Box::new(RustIndexer::new()));
+    r.register(Box::new(TsIndexer::new()));
+    r
+}
+
+fn write(dir: &TempDir, rel: &str, body: &str) -> PathBuf {
+    let abs = dir.path().join(rel);
+    if let Some(parent) = abs.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(&abs, body).unwrap();
+    abs
+}
+
+async fn wait_for<F: FnMut(&ArchEvent) -> bool>(
+    rx: &mut tokio::sync::broadcast::Receiver<ArchEvent>,
+    mut pred: F,
+) -> ArchEvent {
+    let deadline = tokio::time::Instant::now() + TIMEOUT;
+    loop {
+        let now = tokio::time::Instant::now();
+        let remaining = deadline.saturating_duration_since(now);
+        if remaining.is_zero() {
+            panic!("timed out waiting for predicate event");
+        }
+        match timeout(remaining, rx.recv()).await {
+            Ok(Ok(ev)) if pred(&ev) => return ev,
+            Ok(Ok(_)) => continue,
+            Ok(Err(RecvError::Lagged(_))) => continue,
+            Ok(Err(RecvError::Closed)) | Err(_) => {
+                panic!("channel closed or timed out before matching event");
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn boot_indexes_initial_tree_and_serves_queries() {
+    let dir = tempfile::tempdir().unwrap();
+    write(
+        &dir,
+        "src/lib.rs",
+        "pub fn boot_lib() {}\npub struct Foo;\n",
+    );
+    write(
+        &dir,
+        "src/bin.rs",
+        "fn main() {}\n",
+    );
+    write(&dir, "src/types.ts", "export interface Bar { id: string; }\n");
+
+    let svc = KgService::new(registry());
+    let summary = svc.boot(dir.path().to_path_buf()).await.unwrap();
+    assert_eq!(summary.files_indexed, 3, "all three sources indexed");
+
+    // arch.lookup
+    let lib = svc
+        .lookup(LookupParams {
+            file: "src/lib.rs".into(),
+            line: None,
+            col: None,
+        })
+        .await;
+    assert!(!lib.ids.is_empty());
+
+    // arch.subgraph from the file
+    let mut file_id = None;
+    for id in &lib.ids {
+        if let Some(full) = svc.node(*id).await {
+            if matches!(full.node.kind, NodeKind::Common(CommonKind::File)) {
+                file_id = Some(*id);
+                break;
+            }
+        }
+    }
+    let file_id = file_id.expect("file node");
+    let sg = svc
+        .subgraph(SubgraphParams {
+            root: file_id,
+            depth: 2,
+            edges: None,
+            kinds: None,
+            langs: None,
+            node_limit: None,
+        })
+        .await;
+    assert!(
+        sg.nodes.iter().any(|n| n.label == "Foo"),
+        "subgraph should include Foo"
+    );
+
+    // arch.stats
+    let stats = svc.stats().await;
+    assert!(stats.node_count >= 5);
+    assert!(stats.last_index_ms.is_some());
+
+    // arch.roots: with no kind filter, the root directory should appear.
+    let roots = svc
+        .roots(RootsParams {
+            lang: None,
+            kind: None,
+        })
+        .await;
+    assert!(!roots.roots.is_empty());
+
+    // arch.languages
+    let langs = svc.languages();
+    assert!(langs.contains(&Lang::Rust));
+    assert!(langs.contains(&Lang::Ts));
+}
+
+#[tokio::test]
+async fn reindex_path_emits_node_added_changed_removed() {
+    let dir = tempfile::tempdir().unwrap();
+    let lib = write(&dir, "src/lib.rs", "pub fn alpha() {}\n");
+
+    let svc = KgService::new(registry());
+    svc.boot(dir.path().to_path_buf()).await.unwrap();
+
+    let mut rx = svc.subscribe();
+
+    // Replace `alpha` with `beta` and reindex.
+    fs::write(&lib, "pub fn beta() {}\n").unwrap();
+    svc.reindex_path(&lib, IndexReason::Manual).await.unwrap();
+
+    // Expect: IndexStarted, NodeAdded(beta), NodeRemoved(alpha) — order may
+    // vary for the node events. We assert presence of each type.
+    let mut saw_added = false;
+    let mut saw_removed = false;
+    let mut saw_finished = false;
+    let deadline = tokio::time::Instant::now() + TIMEOUT;
+    while !saw_finished {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            panic!("did not observe IndexFinished within timeout");
+        }
+        match timeout(remaining, rx.recv()).await {
+            Ok(Ok(ev)) => match ev {
+                ArchEvent::NodeAdded { node } if node.label == "beta" => saw_added = true,
+                ArchEvent::NodeRemoved { .. } => saw_removed = true,
+                ArchEvent::IndexFinished { .. } => saw_finished = true,
+                _ => {}
+            },
+            _ => panic!("event channel ended"),
+        }
+    }
+    assert!(saw_added, "missing NodeAdded for beta");
+    assert!(saw_removed, "missing NodeRemoved for alpha");
+}
+
+#[tokio::test]
+async fn reindex_after_disk_delete_wipes_file_nodes() {
+    let dir = tempfile::tempdir().unwrap();
+    let p = write(&dir, "src/temp.rs", "pub fn gone() {}\n");
+
+    let svc = KgService::new(registry());
+    svc.boot(dir.path().to_path_buf()).await.unwrap();
+
+    // Confirm `gone` is present.
+    let before = svc
+        .lookup(LookupParams {
+            file: "src/temp.rs".into(),
+            line: None,
+            col: None,
+        })
+        .await;
+    assert!(!before.ids.is_empty());
+
+    fs::remove_file(&p).unwrap();
+    svc.reindex_path(&p, IndexReason::Manual).await.unwrap();
+
+    let after = svc
+        .lookup(LookupParams {
+            file: "src/temp.rs".into(),
+            line: None,
+            col: None,
+        })
+        .await;
+    assert!(
+        after.ids.is_empty(),
+        "deleted file should have no nodes; got {:?}",
+        after.ids
+    );
+}
+
+#[tokio::test]
+async fn watcher_picks_up_disk_changes_and_emits_events() {
+    let dir = tempfile::tempdir().unwrap();
+    let lib = write(&dir, "src/watched.rs", "pub fn first() {}\n");
+
+    let svc = KgService::new(registry());
+    svc.boot(dir.path().to_path_buf()).await.unwrap();
+
+    let mut rx = svc.subscribe();
+    svc.start_watching().await.unwrap();
+
+    // Give the watcher a beat to register.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    fs::write(&lib, "pub fn second() {}\npub struct Added;\n").unwrap();
+
+    // Wait for an IndexFinished from FileWatch, signalling our edit landed.
+    let ev = wait_for(&mut rx, |e| {
+        matches!(
+            e,
+            ArchEvent::IndexFinished { .. }
+        )
+    })
+    .await;
+    let ArchEvent::IndexFinished {
+        nodes_added,
+        nodes_removed,
+        ..
+    } = ev
+    else {
+        unreachable!()
+    };
+    assert!(
+        nodes_added >= 1 && nodes_removed >= 1,
+        "expected at least one add and one remove from file edit; got +{nodes_added} -{nodes_removed}"
+    );
+
+    // The store now reflects the change.
+    let after = svc
+        .lookup(LookupParams {
+            file: "src/watched.rs".into(),
+            line: None,
+            col: None,
+        })
+        .await;
+    let mut labels: Vec<String> = Vec::new();
+    for id in &after.ids {
+        if let Some(n) = svc.node(*id).await {
+            labels.push(n.node.label);
+        }
+    }
+    assert!(labels.iter().any(|l| l == "second"));
+    assert!(labels.iter().any(|l| l == "Added"));
+
+    svc.stop_watching().await;
+}
+
+#[tokio::test]
+async fn touch_emits_agent_touch_with_resolved_node_ids() {
+    let dir = tempfile::tempdir().unwrap();
+    let _lib = write(&dir, "src/lib.rs", "pub fn target_fn() {}\n");
+
+    let svc = KgService::new(registry());
+    svc.boot(dir.path().to_path_buf()).await.unwrap();
+
+    let mut rx = svc.subscribe();
+
+    // pi-mono would call this with the path:line of a tool result.
+    // The function spans line 1, so :1 is sufficient.
+    svc.touch(
+        &["src/lib.rs:1".to_string()],
+        "Read",
+        "R007",
+    )
+    .await;
+
+    let ev = wait_for(&mut rx, |e| matches!(e, ArchEvent::AgentTouch { .. })).await;
+    let ArchEvent::AgentTouch {
+        ids, tool, relay, ..
+    } = ev
+    else {
+        unreachable!()
+    };
+    assert_eq!(tool, "Read");
+    assert_eq!(relay, "R007");
+    assert!(!ids.is_empty(), "should have resolved at least one node");
+
+    // Confirm `target_fn` is among the resolved nodes.
+    let mut found_target = false;
+    for id in ids {
+        if let Some(n) = svc.node(id).await {
+            if n.node.label == "target_fn" {
+                found_target = true;
+                break;
+            }
+        }
+    }
+    assert!(found_target, "AgentTouch should resolve to target_fn");
+}
+
+#[tokio::test]
+async fn reindex_path_before_boot_returns_not_booted() {
+    let svc = KgService::new(registry());
+    let p = std::env::temp_dir().join("does-not-exist.rs");
+    let err = svc
+        .reindex_path(&p, IndexReason::Manual)
+        .await
+        .expect_err("should error before boot");
+    assert!(matches!(err, DaemonError::NotBooted));
+}
+
+#[tokio::test]
+async fn boot_is_idempotent_and_rebinds_to_new_root() {
+    let a = tempfile::tempdir().unwrap();
+    let b = tempfile::tempdir().unwrap();
+    write(&a, "src/a.rs", "pub fn from_a() {}\n");
+    write(&b, "src/b.rs", "pub fn from_b() {}\n");
+
+    let svc = KgService::new(registry());
+    svc.boot(a.path().to_path_buf()).await.unwrap();
+    let stats_a = svc.stats().await;
+    assert!(stats_a.node_count > 0);
+
+    svc.boot(b.path().to_path_buf()).await.unwrap();
+    let stats_b = svc.stats().await;
+    assert!(stats_b.node_count > 0);
+
+    // After rebinding, A's nodes are gone.
+    let from_a = svc
+        .lookup(LookupParams {
+            file: "src/a.rs".into(),
+            line: None,
+            col: None,
+        })
+        .await;
+    assert!(
+        from_a.ids.is_empty(),
+        "boot should wipe state from previous rig"
+    );
+    let from_b = svc
+        .lookup(LookupParams {
+            file: "src/b.rs".into(),
+            line: None,
+            col: None,
+        })
+        .await;
+    assert!(!from_b.ids.is_empty());
+}
+

--- a/yah-kg-store/src/lib.rs
+++ b/yah-kg-store/src/lib.rs
@@ -24,4 +24,4 @@ pub mod walker;
 
 pub use sink::StoreSink;
 pub use store::{Store, StoreError};
-pub use walker::{walk_and_index, IndexerRegistry, WalkSummary};
+pub use walker::{reindex_file, walk_and_index, FileDelta, IndexerRegistry, WalkSummary};

--- a/yah-kg-store/src/walker.rs
+++ b/yah-kg-store/src/walker.rs
@@ -1,21 +1,28 @@
-//! @arch:layer(kg)
+//! @arch:layer(kg_store)
 //! @arch:role(graph)
 //!
 //! Directory walker that drives a registry of `LanguageIndexer`s.
 //!
-//! This is the daemon's Pass 1: walk the rig, emit `Directory` and `File`
-//! nodes with `Contains` edges, then dispatch each file to the matching
-//! indexer for Pass 2 (in-file structure). Indexers are pure; the walker
-//! owns the file I/O.
+//! Pass 1: walk the rig, emit `Directory` and `File` nodes with `Contains`
+//! edges; Pass 2: dispatch each file to the matching indexer for in-file
+//! structure. Indexers are pure; the walker owns the file I/O.
+//!
+//! Also exposes [`reindex_file`] for the daemon's incremental update path:
+//! snapshots a file's nodes, removes them, re-runs the walker on that one
+//! file, and returns a [`FileDelta`] describing what changed so the daemon
+//! can fan out `ArchEvent`s on its broadcast channel.
 
 use crate::sink::StoreSink;
 use crate::store::Store;
-use std::path::Path;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
 use yah_kg::edge::{EdgeId, EdgeKind, EdgeOut};
+use yah_kg::event::ChangedField;
 use yah_kg::ids::{NodeId, NodeRef, Span};
 use yah_kg::indexer::{IndexError, LanguageIndexer};
 use yah_kg::kind::{CommonKind, Lang, NodeKind};
+use yah_kg::rpc::Direction;
 
 /// Maps file extensions to the indexer that should handle them.
 pub struct IndexerRegistry {
@@ -61,6 +68,27 @@ pub struct WalkSummary {
     pub parse_errors: u32,
 }
 
+/// Result of an incremental single-file reindex. Field meanings match the
+/// `ArchEvent` payloads the daemon will emit for each.
+#[derive(Debug, Default, Clone)]
+pub struct FileDelta {
+    pub nodes_added: Vec<NodeRef>,
+    pub nodes_removed: Vec<NodeId>,
+    pub nodes_changed: Vec<(NodeId, Vec<ChangedField>)>,
+    pub edges_added: Vec<EdgeOut>,
+    pub edges_removed: Vec<EdgeId>,
+}
+
+impl FileDelta {
+    pub fn is_empty(&self) -> bool {
+        self.nodes_added.is_empty()
+            && self.nodes_removed.is_empty()
+            && self.nodes_changed.is_empty()
+            && self.edges_added.is_empty()
+            && self.edges_removed.is_empty()
+    }
+}
+
 /// Walk `root`, emit Directory/File nodes + Contains edges, dispatch each
 /// recognized file to its indexer. Symlinks are not followed; hidden
 /// directories (leading `.`) and `target/` are skipped.
@@ -94,35 +122,191 @@ pub fn walk_and_index(
         }
         summary.files_seen += 1;
 
-        let Some(ext) = path.extension().and_then(|s| s.to_str()) else {
-            summary.files_skipped += 1;
-            continue;
-        };
-        let Some(indexer) = registry.for_extension(ext) else {
-            summary.files_skipped += 1;
-            continue;
-        };
-
-        let file_node = push_file(&rel, indexer.lang(), path, &root_canon, store);
-
-        let src = match std::fs::read_to_string(path) {
-            Ok(s) => s,
-            Err(e) => {
-                return Err(IndexError::Io(format!("{}: {}", path.display(), e)));
-            }
-        };
-
-        let mut sink = StoreSink::new(store);
-        match indexer.index_file(Path::new(&rel), &src, &mut sink) {
-            Ok(()) => summary.files_indexed += 1,
-            Err(_) => summary.parse_errors += 1,
+        match index_one_file(&rel, path, &root_canon, store, registry)? {
+            FileOutcome::Indexed => summary.files_indexed += 1,
+            FileOutcome::Skipped => summary.files_skipped += 1,
+            FileOutcome::ParseError => summary.parse_errors += 1,
         }
-
-        // Best-effort: link file → top-level items the indexer just produced
-        // is the indexer's job, not ours. We don't synthesize Contains here.
-        let _ = file_node;
     }
     Ok(summary)
+}
+
+/// Incremental reindex of one file at `file_rel` (relative to `rig_root`).
+///
+/// 1. Snapshots the before-state for the file (nodes + incident edges).
+/// 2. Removes those nodes (the store auto-cleans incident edges).
+/// 3. Re-runs the walker for that single file, restoring the parent
+///    directory chain and re-dispatching to the language indexer.
+/// 4. Diffs before/after and returns a [`FileDelta`].
+///
+/// If the file is missing from disk, the function still wipes the
+/// before-state and returns a delta with `nodes_removed` populated — that
+/// covers the file-deleted case.
+pub fn reindex_file(
+    rig_root: &Path,
+    file_rel: &str,
+    store: &mut Store,
+    registry: &IndexerRegistry,
+) -> Result<FileDelta, IndexError> {
+    let rig_canon = rig_root
+        .canonicalize()
+        .unwrap_or_else(|_| rig_root.to_path_buf());
+    let abs = rig_canon.join(file_rel);
+
+    // 1. Snapshot before-state.
+    let before_nodes: HashMap<NodeId, NodeRef> = store
+        .lookup(file_rel, None)
+        .into_iter()
+        .filter_map(|id| store.node_ref(id).map(|n| (id, n.clone())))
+        .collect();
+    let mut before_edges: HashMap<EdgeId, EdgeOut> = HashMap::new();
+    for id in before_nodes.keys() {
+        for e in store.neighbors(*id, Direction::Both, None) {
+            before_edges.insert(e.id, e);
+        }
+    }
+
+    // 2. Remove the file's nodes.
+    for id in before_nodes.keys() {
+        store.remove_node(*id);
+    }
+
+    // 3. Re-emit if the file still exists.
+    if abs.is_file() {
+        ensure_directory_chain(file_rel, &rig_canon, store);
+        let _ = index_one_file(file_rel, &abs, &rig_canon, store, registry)?;
+    }
+
+    // 4. Snapshot after-state and diff.
+    let after_nodes: HashMap<NodeId, NodeRef> = store
+        .lookup(file_rel, None)
+        .into_iter()
+        .filter_map(|id| store.node_ref(id).map(|n| (id, n.clone())))
+        .collect();
+    let mut after_edges: HashMap<EdgeId, EdgeOut> = HashMap::new();
+    for id in after_nodes.keys() {
+        for e in store.neighbors(*id, Direction::Both, None) {
+            after_edges.insert(e.id, e);
+        }
+    }
+
+    Ok(diff(&before_nodes, &after_nodes, &before_edges, &after_edges))
+}
+
+fn diff(
+    before_nodes: &HashMap<NodeId, NodeRef>,
+    after_nodes: &HashMap<NodeId, NodeRef>,
+    before_edges: &HashMap<EdgeId, EdgeOut>,
+    after_edges: &HashMap<EdgeId, EdgeOut>,
+) -> FileDelta {
+    let mut delta = FileDelta::default();
+
+    for (id, after) in after_nodes {
+        match before_nodes.get(id) {
+            None => delta.nodes_added.push(after.clone()),
+            Some(before) => {
+                let fields = changed_fields(before, after);
+                if !fields.is_empty() {
+                    delta.nodes_changed.push((*id, fields));
+                }
+            }
+        }
+    }
+    for id in before_nodes.keys() {
+        if !after_nodes.contains_key(id) {
+            delta.nodes_removed.push(*id);
+        }
+    }
+
+    for (id, edge) in after_edges {
+        if !before_edges.contains_key(id) {
+            delta.edges_added.push(edge.clone());
+        }
+    }
+    let after_ids: HashSet<EdgeId> = after_edges.keys().copied().collect();
+    for id in before_edges.keys() {
+        if !after_ids.contains(id) {
+            delta.edges_removed.push(*id);
+        }
+    }
+    delta
+}
+
+fn changed_fields(before: &NodeRef, after: &NodeRef) -> Vec<ChangedField> {
+    let mut fields = Vec::new();
+    if before.span != after.span {
+        fields.push(ChangedField::Span);
+    }
+    if before.label != after.label {
+        fields.push(ChangedField::Label);
+    }
+    if before.qualified != after.qualified {
+        fields.push(ChangedField::Qualified);
+    }
+    if before.file != after.file {
+        fields.push(ChangedField::File);
+    }
+    fields
+}
+
+enum FileOutcome {
+    Indexed,
+    Skipped,
+    ParseError,
+}
+
+fn index_one_file(
+    rel: &str,
+    abs: &Path,
+    root: &Path,
+    store: &mut Store,
+    registry: &IndexerRegistry,
+) -> Result<FileOutcome, IndexError> {
+    let Some(ext) = abs.extension().and_then(|s| s.to_str()) else {
+        return Ok(FileOutcome::Skipped);
+    };
+    let Some(indexer) = registry.for_extension(ext) else {
+        return Ok(FileOutcome::Skipped);
+    };
+
+    let _ = push_file(rel, indexer.lang(), abs, root, store);
+
+    let src = std::fs::read_to_string(abs)
+        .map_err(|e| IndexError::Io(format!("{}: {}", abs.display(), e)))?;
+
+    let mut sink = StoreSink::new(store);
+    match indexer.index_file(Path::new(rel), &src, &mut sink) {
+        Ok(()) => Ok(FileOutcome::Indexed),
+        Err(_) => Ok(FileOutcome::ParseError),
+    }
+}
+
+/// Walk up `file_rel`'s ancestor chain and re-emit any missing Directory
+/// nodes (idempotent — already-present nodes dedupe). Used by
+/// [`reindex_file`] to restore the parent edge after wiping the file's
+/// nodes.
+fn ensure_directory_chain(file_rel: &str, root: &Path, store: &mut Store) {
+    // Walk every ancestor of file_rel under root, emitting upward.
+    let mut parts: Vec<&str> = file_rel.split('/').collect();
+    parts.pop(); // drop the file basename
+    let mut acc = PathBuf::new();
+    let mut acc_rel = String::new();
+    push_root_directory(root, store);
+    for part in parts {
+        if !acc_rel.is_empty() {
+            acc_rel.push('/');
+        }
+        acc_rel.push_str(part);
+        acc.push(part);
+        let abs = root.join(&acc);
+        if abs.is_dir() {
+            push_directory(&acc_rel, &abs, root, store);
+        }
+    }
+}
+
+fn push_root_directory(root: &Path, store: &mut Store) {
+    push_directory("", root, root, store);
 }
 
 fn is_skipped(path: &Path, root: &Path) -> bool {


### PR DESCRIPTION
New workspace crate that turns the four KG library crates into a running service. KgService wraps the Store in a tokio RwLock, owns the IndexerRegistry, optionally drives a notify-backed file watcher, and fans ArchEvents out over a tokio broadcast channel. Method shapes mirror the arch.* RPC surface in yah_kg::rpc so Tauri commands can call them as in-process async functions.

Surface:
* KgService::boot(rig_root) — walk_and_index, populate the store, emit IndexStarted{Boot} / IndexFinished. Idempotent: subsequent boots rebind to a new root and wipe the previous state.
* KgService::start_watching / stop_watching — opt-in notify watcher with a 50ms debounce window to coalesce editor save bursts. Watcher reindexes per-file and emits NodeAdded / NodeChanged / NodeRemoved / EdgeAdded / EdgeRemoved deltas plus IndexStarted{FileWatch} / IndexFinished envelope events.
* KgService::reindex_path(abs_path, reason) — manual reindex used by pi-mono after agent edits (reason=AgentEdit). Computes the same per-node-field diff under the hood.
* KgService::touch(paths, tool, relay) — resolves agent tool-result path:line strings to NodeIds via store lookup and emits AgentTouch for the UI's candle-pulse overlay.
* Read queries: subgraph, lookup, node, neighbors, roots, stats, languages — all match the contract's RPC param/result shapes.

Concurrency:
* Single Store behind RwLock — queries take read locks (parallel), reindex writes are serialized.
* notify callback runs on its own OS thread, forwards events through mpsc to a tokio task that debounces and dispatches.
* broadcast channel for ArchEvents so multiple subscribers (Tauri commands, internal listeners, future JSON-RPC fanout) tail the stream without back-pressuring publishers.

Supporting changes in yah-kg-store:
* New reindex_file(rig_root, file_rel, store, registry) -> FileDelta helper. Snapshots the file's nodes + incident edges, removes them, re-runs the walker for that single file, restores the parent directory chain, and diffs before/after into a FileDelta the daemon translates into ArchEvents. Handles file-deleted by emitting only removals.
* FileDelta type carrying nodes_added/changed/removed + edges_added/removed for the daemon to emit directly.
* Refactored walker.rs to share the per-file index logic between walk_and_index and reindex_file.

Tests (7 e2e):
* boot indexes initial tree and serves all the read queries
* reindex_path emits NodeAdded + NodeRemoved + IndexFinished
* reindex after disk delete wipes file's nodes
* watcher picks up disk changes and emits events end-to-end
* touch emits AgentTouch with resolved node ids
* reindex before boot returns NotBooted
* boot is idempotent and rebinds to new root

Implementation note caught in testing: the eligibility check rejects paths that traverse a dot-prefixed directory, but had to be applied to the rig-RELATIVE path, not the absolute one — otherwise tempdirs under /tmp/.tmpXXX/ get filtered out.