### PR TITLE
yah-kg-anno: tag/flow/rule annotation overlay + daemon Pass 4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1570,6 +1570,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "yah-kg-anno"
+version = "0.6.0"
+dependencies = [
+ "serde",
+ "tempfile",
+ "thiserror 1.0.69",
+ "yah-kg",
+ "yah-kg-rust",
+ "yah-kg-store",
+ "yah-kg-ts",
+]
+
+[[package]]
 name = "yah-kg-daemon"
 version = "0.6.0"
 dependencies = [
@@ -1579,6 +1592,7 @@ dependencies = [
  "tokio",
  "tracing",
  "yah-kg",
+ "yah-kg-anno",
  "yah-kg-rust",
  "yah-kg-store",
  "yah-kg-ts",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "yah-kg-rust",
     "yah-kg-ts",
     "yah-kg-daemon",
+    "yah-kg-anno",
 ]
 resolver = "2"
 

--- a/yah-kg-anno/Cargo.toml
+++ b/yah-kg-anno/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "yah-kg-anno"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Annotation overlay (tags, flows, rules) on top of the yah knowledge graph"
+
+[dependencies]
+yah-kg = { path = "../yah-kg" }
+yah-kg-store = { path = "../yah-kg-store" }
+serde = { version = "1.0", features = ["derive"] }
+thiserror = "1.0"
+
+[dev-dependencies]
+yah-kg-rust = { path = "../yah-kg-rust" }
+yah-kg-ts = { path = "../yah-kg-ts" }
+tempfile = "3"

--- a/yah-kg-anno/src/apply.rs
+++ b/yah-kg-anno/src/apply.rs
@@ -1,0 +1,276 @@
+//! @arch:layer(kg_store)
+//! @arch:role(graph)
+//!
+//! Pass 4: apply parsed annotations to the graph.
+//!
+//! For each node with a doc string: parse `@yah:` directives, materialize
+//! synthetic Tag nodes + Tag edges, resolve Flow targets by qualified-name
+//! suffix, and write `AnnotationRef` values into the [`AnnotationIndex`].
+//!
+//! Tag node identity: `NodeId::compute(Lang::Rust, &tag.qualified(),
+//! "<tag>")`. The Lang is a sentinel — Tag nodes are language-agnostic
+//! but the contract requires assigning some `Lang`. The fixed
+//! `"<tag>"` file marker keeps tag ids from colliding with structural
+//! nodes that happen to share a qualified name.
+
+use crate::index::AnnotationIndex;
+use crate::parser::{parse_doc, RawAnnotation};
+use std::collections::HashSet;
+use yah_kg::anno::{AnnotationKind, AnnotationRef, TagRef};
+use yah_kg::edge::{EdgeId, EdgeKind, EdgeOut};
+use yah_kg::ids::{NodeId, NodeRef, Span};
+use yah_kg::kind::{CommonKind, Lang, NodeKind};
+use yah_kg_store::Store;
+
+const TAG_FILE_SENTINEL: &str = "<tag>";
+
+#[derive(Debug, Default, Clone)]
+pub struct ApplySummary {
+    pub nodes_scanned: u32,
+    pub annotations_attached: u32,
+    pub tag_edges_added: u32,
+    pub flow_edges_added: u32,
+    pub flows_unresolved: u32,
+    pub parse_errors: u32,
+}
+
+/// Run the annotation pass over every node currently in `store`. Replaces
+/// any previously-attached annotations and Tag/Flow edges for each node
+/// — call this after each reindex.
+///
+/// `node_filter` lets the daemon scope work to a single file's nodes
+/// during incremental reindex; pass `None` for "every node".
+pub fn apply_pass(
+    store: &mut Store,
+    index: &mut AnnotationIndex,
+    node_filter: Option<&HashSet<NodeId>>,
+) -> ApplySummary {
+    let mut summary = ApplySummary::default();
+
+    // Snapshot the targets so we can mutate the store inside the loop.
+    let targets: Vec<(NodeId, Option<String>)> = collect_targets(store, node_filter);
+
+    for (id, doc) in targets {
+        summary.nodes_scanned += 1;
+        let result = apply_to_node(store, index, id, doc.as_deref());
+        summary.annotations_attached += result.annotations_attached;
+        summary.tag_edges_added += result.tag_edges_added;
+        summary.flow_edges_added += result.flow_edges_added;
+        summary.flows_unresolved += result.flows_unresolved;
+        summary.parse_errors += result.parse_errors;
+    }
+    summary
+}
+
+fn collect_targets(
+    store: &Store,
+    filter: Option<&HashSet<NodeId>>,
+) -> Vec<(NodeId, Option<String>)> {
+    // We need every node in the store. The Store doesn't expose an
+    // iterator; use stats() / lookup over each known file. The cheap
+    // path: drain all by_file entries.
+    let mut out = Vec::new();
+    for entry in store.all_node_refs() {
+        if let Some(f) = filter {
+            if !f.contains(&entry.id) {
+                continue;
+            }
+        }
+        // Skip synthetic Tag nodes — they don't author annotations.
+        if matches!(entry.kind, NodeKind::Common(CommonKind::Tag)) {
+            continue;
+        }
+        let doc = store.node_full(entry.id).and_then(|n| n.doc);
+        out.push((entry.id, doc));
+    }
+    out
+}
+
+#[derive(Debug, Default)]
+pub struct PerNodeOutcome {
+    pub annotations_attached: u32,
+    pub tag_edges_added: u32,
+    pub flow_edges_added: u32,
+    pub flows_unresolved: u32,
+    pub parse_errors: u32,
+}
+
+/// Apply annotations for a single node. Public for callers that already
+/// know which nodes need a refresh (e.g. the daemon during a per-file
+/// reindex). Replaces any previously attached annotations + Tag edges.
+pub fn apply_to_node(
+    store: &mut Store,
+    index: &mut AnnotationIndex,
+    node: NodeId,
+    doc: Option<&str>,
+) -> PerNodeOutcome {
+    // Wipe any previous Tag edges from this node — they're entirely
+    // derived from the doc, so we re-build from scratch.
+    let prev_tag_edges: Vec<EdgeId> = store
+        .neighbors(node, yah_kg::rpc::Direction::Out, Some(&[EdgeKind::Tag]))
+        .into_iter()
+        .map(|e| e.id)
+        .collect();
+    for eid in prev_tag_edges {
+        store.remove_edge(eid);
+    }
+    let prev_flow_edges: Vec<EdgeId> = store
+        .neighbors(node, yah_kg::rpc::Direction::Out, Some(&[EdgeKind::Flow]))
+        .into_iter()
+        .map(|e| e.id)
+        .collect();
+    for eid in prev_flow_edges {
+        store.remove_edge(eid);
+    }
+    index.remove(node);
+
+    let Some(doc) = doc.filter(|d| !d.is_empty()) else {
+        return PerNodeOutcome::default();
+    };
+
+    let (parsed, errors) = parse_doc(doc);
+    let mut outcome = PerNodeOutcome {
+        parse_errors: errors.len() as u32,
+        ..Default::default()
+    };
+
+    // The anchor's source file/line we report on each AnnotationRef. The
+    // file is the structural node's file; the line is the node's start
+    // line + the parser's line_offset (parser counts within the doc; the
+    // doc started at or near the node's first line — close enough for
+    // human-pointing purposes).
+    let anchor_file = store
+        .node_ref(node)
+        .map(|n| n.file.clone())
+        .unwrap_or_default();
+    let anchor_start = store
+        .node_ref(node)
+        .map(|n| n.span.start_line)
+        .unwrap_or(1);
+
+    let mut anns = Vec::new();
+    for p in parsed {
+        match p.anno {
+            RawAnnotation::Tag(tags) => {
+                for tag in tags {
+                    ensure_tag_node(store, &tag);
+                    let tag_id = tag_node_id(&tag);
+                    let edge = EdgeOut {
+                        id: EdgeId::compute(node, tag_id, &EdgeKind::Tag),
+                        from: node,
+                        to: tag_id,
+                        kind: EdgeKind::Tag,
+                        annotations: vec![],
+                    };
+                    if store.upsert_edge(edge) {
+                        outcome.tag_edges_added += 1;
+                    }
+                    anns.push(AnnotationRef {
+                        anchor: node,
+                        source_file: anchor_file.clone(),
+                        source_line: anchor_start + p.line_offset.saturating_sub(1),
+                        kind: AnnotationKind::Tag(tag),
+                    });
+                    outcome.annotations_attached += 1;
+                }
+            }
+            RawAnnotation::Flow {
+                from_qualified: _,
+                to_qualified,
+                reason,
+            } => {
+                if let Some(target_id) = resolve_qualified(store, &to_qualified) {
+                    let edge = EdgeOut {
+                        id: EdgeId::compute(node, target_id, &EdgeKind::Flow),
+                        from: node,
+                        to: target_id,
+                        kind: EdgeKind::Flow,
+                        annotations: vec![],
+                    };
+                    if store.upsert_edge(edge) {
+                        outcome.flow_edges_added += 1;
+                    }
+                } else {
+                    outcome.flows_unresolved += 1;
+                }
+                anns.push(AnnotationRef {
+                    anchor: node,
+                    source_file: anchor_file.clone(),
+                    source_line: anchor_start + p.line_offset.saturating_sub(1),
+                    kind: AnnotationKind::Flow {
+                        to_qualified,
+                        reason,
+                    },
+                });
+                outcome.annotations_attached += 1;
+            }
+            RawAnnotation::Rule { rule_kind, args } => {
+                anns.push(AnnotationRef {
+                    anchor: node,
+                    source_file: anchor_file.clone(),
+                    source_line: anchor_start + p.line_offset.saturating_sub(1),
+                    kind: AnnotationKind::Rule { rule_kind, args },
+                });
+                outcome.annotations_attached += 1;
+            }
+        }
+    }
+
+    if !anns.is_empty() {
+        index.set(node, anns);
+    }
+    outcome
+}
+
+fn tag_node_id(tag: &TagRef) -> NodeId {
+    NodeId::compute(Lang::Rust, &tag.qualified(), TAG_FILE_SENTINEL)
+}
+
+fn ensure_tag_node(store: &mut Store, tag: &TagRef) {
+    let id = tag_node_id(tag);
+    if store.node_ref(id).is_some() {
+        return;
+    }
+    store.upsert_node(NodeRef {
+        id,
+        lang: Lang::Rust,
+        kind: NodeKind::Common(CommonKind::Tag),
+        label: tag.label(),
+        qualified: tag.qualified(),
+        file: TAG_FILE_SENTINEL.to_string(),
+        span: Span::point(0, 0),
+        synthetic: true,
+    });
+}
+
+/// Resolve a `to_qualified` string from a flow annotation to a NodeId.
+///
+/// Strategy: prefer an exact qualified-name match; fall back to a unique
+/// suffix match (qualified ends with `::needle`). If the suffix match is
+/// ambiguous we drop the edge — flows are high-signal annotations and
+/// should be authored unambiguously.
+fn resolve_qualified(store: &Store, needle: &str) -> Option<NodeId> {
+    let needle = needle.trim();
+    if needle.is_empty() {
+        return None;
+    }
+    let mut exact: Option<NodeId> = None;
+    let mut suffix: Vec<NodeId> = Vec::new();
+    for n in store.all_node_refs() {
+        if n.qualified == needle {
+            exact = Some(n.id);
+            break;
+        }
+        if n.qualified.ends_with(&format!("::{needle}")) {
+            suffix.push(n.id);
+        }
+    }
+    if let Some(id) = exact {
+        return Some(id);
+    }
+    if suffix.len() == 1 {
+        return suffix.into_iter().next();
+    }
+    None
+}
+

--- a/yah-kg-anno/src/index.rs
+++ b/yah-kg-anno/src/index.rs
@@ -1,0 +1,59 @@
+//! @arch:layer(kg_store)
+//! @arch:role(graph)
+//!
+//! Side index from `NodeId` to its `AnnotationRef`s.
+//!
+//! Annotations live both in the graph (as Tag/Flow edges) and in this
+//! side index (as typed `AnnotationRef` values). The index powers
+//! `arch.node`'s `annotations` field — the UI fetches one node and gets
+//! its full overlay in one round-trip without traversing the graph.
+
+use std::collections::HashMap;
+use yah_kg::anno::AnnotationRef;
+use yah_kg::ids::NodeId;
+
+#[derive(Debug, Default, Clone)]
+pub struct AnnotationIndex {
+    by_node: HashMap<NodeId, Vec<AnnotationRef>>,
+}
+
+impl AnnotationIndex {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Wholesale-replace the annotations attached to `node`. Called by the
+    /// applier when a file is reindexed — annotations on a node are
+    /// always derived from one source location, so atomic replace is
+    /// the right semantics.
+    pub fn set(&mut self, node: NodeId, anns: Vec<AnnotationRef>) {
+        if anns.is_empty() {
+            self.by_node.remove(&node);
+        } else {
+            self.by_node.insert(node, anns);
+        }
+    }
+
+    pub fn get(&self, node: NodeId) -> &[AnnotationRef] {
+        self.by_node
+            .get(&node)
+            .map(|v| v.as_slice())
+            .unwrap_or(&[])
+    }
+
+    pub fn remove(&mut self, node: NodeId) {
+        self.by_node.remove(&node);
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (NodeId, &[AnnotationRef])> {
+        self.by_node.iter().map(|(k, v)| (*k, v.as_slice()))
+    }
+
+    pub fn len(&self) -> usize {
+        self.by_node.values().map(|v| v.len()).sum()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.by_node.is_empty()
+    }
+}

--- a/yah-kg-anno/src/lib.rs
+++ b/yah-kg-anno/src/lib.rs
@@ -1,0 +1,30 @@
+//! @arch:layer(kg_store)
+//! @arch:role(extract)
+//!
+//! `yah-kg-anno` — annotation overlay for the structural knowledge graph.
+//!
+//! Reads `@yah:` directives from doc strings already attached to nodes
+//! (by the language indexers' `push_doc` calls), parses them into typed
+//! `AnnotationRef` values, and applies them to the graph:
+//!
+//! * **Tags** materialize as synthetic `Tag` nodes plus `EdgeKind::Tag`
+//!   edges from the annotated structural node to the tag.
+//! * **Flows** materialize as `EdgeKind::Flow` edges from the annotated
+//!   node to whichever node currently matches the `to_qualified` string
+//!   (suffix match on the qualified name; ambiguous matches are dropped
+//!   with a warning).
+//! * **Rules** are parsed but not yet validated — the v1 contract
+//!   reserves the type so authors can start writing them.
+//!
+//! Pass 4 driver: [`apply_pass`] walks every node in the store, scans
+//! its doc for annotations, and writes the result into both the
+//! [`AnnotationIndex`] (side index keyed by `NodeId`) and the graph
+//! (synthetic Tag nodes + Tag/Flow edges).
+
+pub mod apply;
+pub mod index;
+pub mod parser;
+
+pub use apply::{apply_pass, apply_to_node, ApplySummary};
+pub use index::AnnotationIndex;
+pub use parser::{parse_doc, ParseError, RawAnnotation};

--- a/yah-kg-anno/src/parser.rs
+++ b/yah-kg-anno/src/parser.rs
@@ -1,0 +1,431 @@
+//! @arch:layer(kg_store)
+//! @arch:role(extract)
+//!
+//! Doc-string annotation parser.
+//!
+//! Input: a doc string already extracted by a language indexer (the
+//! comment markers `///`, `//!`, `/** */`, `*` have been stripped). Each
+//! line of the doc is examined for a `@yah:<kind>(<payload>)` directive.
+//!
+//! Robust to:
+//! * arbitrary leading whitespace,
+//! * payloads containing balanced parens (we count nesting),
+//! * unicode arrows `→` and ASCII `->` for flows,
+//! * commented-out lines and prose around the directive.
+//!
+//! Permissive on payload form within each kind — authors get a clean
+//! parse error message rather than silent dropping.
+
+use yah_kg::anno::TagRef;
+
+/// Pre-resolution annotation: like `AnnotationKind` but without the
+/// anchor `NodeId` (which is supplied by the applier when it knows
+/// which node owns the doc string).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RawAnnotation {
+    Tag(Vec<TagRef>),
+    Flow {
+        from_qualified: Option<String>,
+        to_qualified: String,
+        reason: Option<String>,
+    },
+    Rule {
+        rule_kind: String,
+        args: Vec<String>,
+    },
+}
+
+/// One parsed annotation plus the relative line within the doc string
+/// where it was found (1-based; index 1 is the first line of `doc`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedAnnotation {
+    pub anno: RawAnnotation,
+    pub line_offset: u32,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ParseError {
+    #[error("malformed @yah:{kind} payload at line offset {line}: {message}")]
+    Malformed {
+        kind: String,
+        line: u32,
+        message: String,
+    },
+}
+
+/// Scan a doc string for `@yah:` directives. Returns one `ParsedAnnotation`
+/// per directive in source order. Lines that don't contain a directive
+/// are silently ignored. Malformed directives become `ParseError`s but
+/// don't abort the rest of the scan — the caller decides whether to
+/// surface them or skip.
+pub fn parse_doc(doc: &str) -> (Vec<ParsedAnnotation>, Vec<ParseError>) {
+    let mut out = Vec::new();
+    let mut errors = Vec::new();
+
+    for (idx, line) in doc.lines().enumerate() {
+        let line_no = (idx + 1) as u32;
+        let mut cursor = line;
+
+        loop {
+            let Some(rest) = find_directive(cursor) else {
+                break;
+            };
+            // `rest` starts at the first char after `@yah:`.
+            let (kind, body, after) = match split_directive(rest) {
+                Some(v) => v,
+                None => break,
+            };
+            cursor = after;
+
+            match kind {
+                "tag" => match parse_tag_body(&body) {
+                    Ok(tags) if !tags.is_empty() => out.push(ParsedAnnotation {
+                        anno: RawAnnotation::Tag(tags),
+                        line_offset: line_no,
+                    }),
+                    Ok(_) => errors.push(ParseError::Malformed {
+                        kind: "tag".into(),
+                        line: line_no,
+                        message: "no tags inside the parentheses".into(),
+                    }),
+                    Err(e) => errors.push(ParseError::Malformed {
+                        kind: "tag".into(),
+                        line: line_no,
+                        message: e,
+                    }),
+                },
+                "flow" => match parse_flow_body(&body) {
+                    Ok(flow) => out.push(ParsedAnnotation {
+                        anno: flow,
+                        line_offset: line_no,
+                    }),
+                    Err(e) => errors.push(ParseError::Malformed {
+                        kind: "flow".into(),
+                        line: line_no,
+                        message: e,
+                    }),
+                },
+                "rule" => match parse_rule_body(&body) {
+                    Ok(rule) => out.push(ParsedAnnotation {
+                        anno: rule,
+                        line_offset: line_no,
+                    }),
+                    Err(e) => errors.push(ParseError::Malformed {
+                        kind: "rule".into(),
+                        line: line_no,
+                        message: e,
+                    }),
+                },
+                other => errors.push(ParseError::Malformed {
+                    kind: other.to_string(),
+                    line: line_no,
+                    message: "unknown @yah: directive".into(),
+                }),
+            }
+        }
+    }
+
+    (out, errors)
+}
+
+/// Find the next `@yah:` substring in `s` and return everything after the
+/// colon. Returns `None` if no directive on the line.
+fn find_directive(s: &str) -> Option<&str> {
+    s.find("@yah:").map(|i| &s[i + 5..])
+}
+
+/// Given input that begins right after `@yah:`, parse out
+/// `(kind, body, remaining_after_directive)`. Body excludes the outer
+/// parentheses. Returns `None` if the directive is malformed beyond
+/// recovery (in which case parsing of the rest of the line stops).
+fn split_directive(s: &str) -> Option<(&str, String, &str)> {
+    // Kind is the run of identifier-like chars before `(`.
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() && (bytes[i].is_ascii_alphabetic() || bytes[i] == b'_') {
+        i += 1;
+    }
+    if i == 0 {
+        return None;
+    }
+    let kind = &s[..i];
+    if bytes.get(i)? != &b'(' {
+        return None;
+    }
+    let body_start = i + 1;
+    let mut depth = 1;
+    let mut j = body_start;
+    while j < bytes.len() {
+        match bytes[j] {
+            b'(' => depth += 1,
+            b')' => {
+                depth -= 1;
+                if depth == 0 {
+                    let body = s[body_start..j].to_string();
+                    return Some((kind, body, &s[j + 1..]));
+                }
+            }
+            _ => {}
+        }
+        j += 1;
+    }
+    None // unterminated
+}
+
+fn parse_tag_body(body: &str) -> Result<Vec<TagRef>, String> {
+    let mut tags = Vec::new();
+    for part in body.split(',') {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
+        if !is_valid_tag_string(part) {
+            return Err(format!("invalid tag {:?}", part));
+        }
+        let tag = match part.split_once(':') {
+            Some((ns, name)) => TagRef::namespaced(ns.trim(), name.trim()),
+            None => TagRef::new(part),
+        };
+        tags.push(tag);
+    }
+    Ok(tags)
+}
+
+fn is_valid_tag_string(s: &str) -> bool {
+    if s.is_empty() {
+        return false;
+    }
+    s.chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == ':')
+}
+
+fn parse_flow_body(body: &str) -> Result<RawAnnotation, String> {
+    // Split off the optional ", \"reason\"" tail.
+    let (head, reason) = split_off_reason(body);
+    // Find `→` (unicode) or `->` (ASCII).
+    let (from_part, to_part) = if let Some(idx) = head.find('→') {
+        (&head[..idx], &head[idx + '→'.len_utf8()..])
+    } else if let Some(idx) = head.find("->") {
+        (&head[..idx], &head[idx + 2..])
+    } else {
+        // Single-target form: flow(target) — implicit "from" is the
+        // annotated node itself. The applier supplies the anchor.
+        return Ok(RawAnnotation::Flow {
+            from_qualified: None,
+            to_qualified: head.trim().to_string(),
+            reason,
+        });
+    };
+    let from = from_part.trim();
+    let to = to_part.trim();
+    if to.is_empty() {
+        return Err("missing flow target".into());
+    }
+    Ok(RawAnnotation::Flow {
+        from_qualified: if from.is_empty() {
+            None
+        } else {
+            Some(from.to_string())
+        },
+        to_qualified: to.to_string(),
+        reason,
+    })
+}
+
+fn split_off_reason(body: &str) -> (&str, Option<String>) {
+    // Reason is the last `"..."` quoted segment after a comma, when present.
+    let Some(comma_idx) = body.rfind(',') else {
+        return (body, None);
+    };
+    let tail = body[comma_idx + 1..].trim();
+    if let (Some(stripped), true) = (tail.strip_prefix('"').and_then(|s| s.strip_suffix('"')), tail.starts_with('"')) {
+        (&body[..comma_idx], Some(stripped.to_string()))
+    } else {
+        (body, None)
+    }
+}
+
+/// Split on top-level `,` only — treats commas inside `(...)` as part of
+/// the argument. So `cycle(a, b, c), other` splits to two args, not five.
+fn split_top_level_commas(s: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut cur = String::new();
+    let mut depth = 0i32;
+    for ch in s.chars() {
+        match ch {
+            '(' | '[' | '{' => {
+                depth += 1;
+                cur.push(ch);
+            }
+            ')' | ']' | '}' => {
+                depth -= 1;
+                cur.push(ch);
+            }
+            ',' if depth == 0 => {
+                let trimmed = cur.trim();
+                if !trimmed.is_empty() {
+                    out.push(trimmed.to_string());
+                }
+                cur.clear();
+            }
+            _ => cur.push(ch),
+        }
+    }
+    let trimmed = cur.trim();
+    if !trimmed.is_empty() {
+        out.push(trimmed.to_string());
+    }
+    out
+}
+
+fn parse_rule_body(body: &str) -> Result<RawAnnotation, String> {
+    // Form: rule_kind: arg1, arg2, ...
+    let (kind_part, arg_part) = body.split_once(':').ok_or_else(|| {
+        "expected `rule_kind: args` form (e.g. `no-import-of: tag(view)`)".to_string()
+    })?;
+    let rule_kind = kind_part.trim();
+    if rule_kind.is_empty() {
+        return Err("empty rule kind".into());
+    }
+    let args = split_top_level_commas(arg_part);
+    Ok(RawAnnotation::Rule {
+        rule_kind: rule_kind.to_string(),
+        args,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_single_tag() {
+        let (out, errs) = parse_doc("@yah:tag(audio)");
+        assert!(errs.is_empty());
+        assert_eq!(
+            out,
+            vec![ParsedAnnotation {
+                anno: RawAnnotation::Tag(vec![TagRef::new("audio")]),
+                line_offset: 1,
+            }]
+        );
+    }
+
+    #[test]
+    fn parses_multiple_tags_in_one_directive() {
+        let (out, errs) = parse_doc("@yah:tag(audio, hot-path, layer:core)");
+        assert!(errs.is_empty(), "{errs:?}");
+        assert_eq!(out.len(), 1);
+        let RawAnnotation::Tag(tags) = &out[0].anno else {
+            panic!("expected tag, got {:?}", out[0]);
+        };
+        assert_eq!(tags.len(), 3);
+        assert_eq!(tags[0], TagRef::new("audio"));
+        assert_eq!(tags[1], TagRef::new("hot-path"));
+        assert_eq!(tags[2], TagRef::namespaced("layer", "core"));
+    }
+
+    #[test]
+    fn parses_flow_with_arrow_and_reason() {
+        let (out, errs) = parse_doc(
+            "Doc text first.\n@yah:flow(audio::mixer → dispatch::loop, \"shared frame buffer\")",
+        );
+        assert!(errs.is_empty(), "{errs:?}");
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].line_offset, 2);
+        let RawAnnotation::Flow {
+            from_qualified,
+            to_qualified,
+            reason,
+        } = &out[0].anno
+        else {
+            panic!("expected flow, got {:?}", out[0]);
+        };
+        assert_eq!(from_qualified.as_deref(), Some("audio::mixer"));
+        assert_eq!(to_qualified, "dispatch::loop");
+        assert_eq!(reason.as_deref(), Some("shared frame buffer"));
+    }
+
+    #[test]
+    fn parses_flow_with_ascii_arrow() {
+        let (out, errs) = parse_doc("@yah:flow(a -> b)");
+        assert!(errs.is_empty(), "{errs:?}");
+        let RawAnnotation::Flow {
+            to_qualified,
+            from_qualified,
+            ..
+        } = &out[0].anno
+        else {
+            panic!()
+        };
+        assert_eq!(to_qualified, "b");
+        assert_eq!(from_qualified.as_deref(), Some("a"));
+    }
+
+    #[test]
+    fn parses_implicit_from_flow() {
+        let (out, errs) = parse_doc("@yah:flow(target_module::Thing)");
+        assert!(errs.is_empty(), "{errs:?}");
+        let RawAnnotation::Flow {
+            from_qualified,
+            to_qualified,
+            ..
+        } = &out[0].anno
+        else {
+            panic!()
+        };
+        assert_eq!(from_qualified, &None);
+        assert_eq!(to_qualified, "target_module::Thing");
+    }
+
+    #[test]
+    fn parses_rule() {
+        let (out, errs) = parse_doc("@yah:rule(no-import-of: tag(view), tag(io))");
+        assert!(errs.is_empty(), "{errs:?}");
+        let RawAnnotation::Rule { rule_kind, args } = &out[0].anno else {
+            panic!()
+        };
+        assert_eq!(rule_kind, "no-import-of");
+        assert_eq!(args, &vec!["tag(view)".to_string(), "tag(io)".to_string()]);
+    }
+
+    #[test]
+    fn rejects_unknown_directive() {
+        let (out, errs) = parse_doc("@yah:wat(stuff)");
+        assert!(out.is_empty());
+        assert_eq!(errs.len(), 1);
+    }
+
+    #[test]
+    fn handles_multi_line_doc_with_prose() {
+        let doc = "Top-level mixer.\n\nBack story prose.\n@yah:tag(audio)\nMore prose.";
+        let (out, errs) = parse_doc(doc);
+        assert!(errs.is_empty());
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].line_offset, 4);
+    }
+
+    #[test]
+    fn ignores_doc_without_directives() {
+        let (out, errs) = parse_doc("just prose, no @anno here");
+        assert!(out.is_empty());
+        assert!(errs.is_empty());
+    }
+
+    #[test]
+    fn handles_balanced_parens_in_payload() {
+        let (out, errs) = parse_doc("@yah:rule(no-cycle: cycle(a, b, c))");
+        assert!(errs.is_empty(), "{errs:?}");
+        let RawAnnotation::Rule { args, .. } = &out[0].anno else {
+            panic!()
+        };
+        assert_eq!(args, &vec!["cycle(a, b, c)".to_string()]);
+    }
+
+    #[test]
+    fn surfaces_invalid_tag_chars() {
+        let (out, errs) = parse_doc("@yah:tag(bad space)");
+        assert!(out.is_empty(), "should not emit invalid tag");
+        assert_eq!(errs.len(), 1);
+    }
+}

--- a/yah-kg-anno/tests/e2e.rs
+++ b/yah-kg-anno/tests/e2e.rs
@@ -1,0 +1,225 @@
+//! End-to-end annotation tests: index a fixture file, run apply_pass,
+//! query the resulting graph + annotation index.
+
+use std::path::Path;
+use yah_kg::anno::{AnnotationKind, TagRef};
+use yah_kg::edge::EdgeKind;
+use yah_kg::indexer::LanguageIndexer;
+use yah_kg::kind::{CommonKind, NodeKind};
+use yah_kg::rpc::Direction;
+use yah_kg_anno::{apply_pass, AnnotationIndex};
+use yah_kg_rust::RustIndexer;
+use yah_kg_store::{Store, StoreSink};
+
+const SRC: &str = r#"
+//! @yah:tag(layer:core)
+//!
+//! Crate-level mixer module.
+
+/// Top-level mixer.
+///
+/// @yah:tag(audio, hot-path)
+pub struct AudioMixer {
+    pub gain: f32,
+}
+
+/// Frame buffer dispatcher.
+///
+/// @yah:flow(AudioMixer, "shared frame buffer")
+pub struct Dispatcher;
+
+/// @yah:rule(no-import-of: tag(view))
+pub mod inner {}
+
+/// Just docs, no annotations.
+pub fn untagged() {}
+
+/// Bad tag (space inside) should produce a parse error and not attach.
+///
+/// @yah:tag(invalid space)
+pub fn malformed() {}
+"#;
+
+fn build() -> (Store, AnnotationIndex) {
+    let mut store = Store::new();
+    {
+        let mut sink = StoreSink::new(&mut store);
+        RustIndexer::new()
+            .index_file(Path::new("src/lib.rs"), SRC, &mut sink)
+            .expect("indexer succeeds");
+    }
+    let mut idx = AnnotationIndex::new();
+    apply_pass(&mut store, &mut idx, None);
+    (store, idx)
+}
+
+fn lookup_label(store: &Store, label: &str) -> Option<yah_kg::ids::NodeId> {
+    store
+        .all_node_refs()
+        .find(|n| n.label == label)
+        .map(|n| n.id)
+}
+
+#[test]
+fn tag_creates_synthetic_tag_nodes_and_tag_edges() {
+    let (store, _idx) = build();
+
+    // The synthetic Tag nodes exist.
+    let tag_nodes: Vec<&yah_kg::ids::NodeRef> = store
+        .all_node_refs()
+        .filter(|n| matches!(n.kind, NodeKind::Common(CommonKind::Tag)))
+        .collect();
+    let tag_qualified: Vec<&str> = tag_nodes.iter().map(|n| n.qualified.as_str()).collect();
+    assert!(
+        tag_qualified.contains(&"tag:layer:core"),
+        "missing layer:core tag; got {tag_qualified:?}"
+    );
+    assert!(tag_qualified.contains(&"tag:audio"), "missing audio tag");
+    assert!(tag_qualified.contains(&"tag:hot-path"), "missing hot-path tag");
+
+    // The struct has Tag edges to audio + hot-path.
+    let mixer = lookup_label(&store, "AudioMixer").expect("AudioMixer node");
+    let outs = store.neighbors(mixer, Direction::Out, Some(&[EdgeKind::Tag]));
+    let targets: Vec<String> = outs
+        .iter()
+        .filter_map(|e| store.node_ref(e.to).map(|n| n.label.clone()))
+        .collect();
+    assert!(
+        targets.contains(&"audio".to_string())
+            && targets.contains(&"hot-path".to_string()),
+        "AudioMixer should be tagged audio + hot-path; got {targets:?}"
+    );
+}
+
+#[test]
+fn tag_attaches_to_file_node_for_inner_doc_comments() {
+    let (store, _idx) = build();
+    // `//! @yah:tag(layer:core)` at file top should attach to the File node.
+    let file_id = lookup_label(&store, "lib.rs").expect("file node");
+    let outs = store.neighbors(file_id, Direction::Out, Some(&[EdgeKind::Tag]));
+    let targets: Vec<String> = outs
+        .iter()
+        .filter_map(|e| store.node_ref(e.to).map(|n| n.label.clone()))
+        .collect();
+    assert!(
+        targets.contains(&"layer:core".to_string()),
+        "file should be tagged layer:core; got {targets:?}"
+    );
+}
+
+#[test]
+fn flow_resolves_within_file_and_emits_flow_edge() {
+    let (store, _idx) = build();
+    let dispatcher = lookup_label(&store, "Dispatcher").expect("Dispatcher");
+    let outs = store.neighbors(dispatcher, Direction::Out, Some(&[EdgeKind::Flow]));
+    assert_eq!(outs.len(), 1, "Dispatcher should have one flow edge");
+    assert_eq!(
+        store.node_ref(outs[0].to).map(|n| n.label.as_str()),
+        Some("AudioMixer")
+    );
+}
+
+#[test]
+fn annotation_index_carries_typed_annotations_per_node() {
+    let (store, idx) = build();
+
+    let mixer = lookup_label(&store, "AudioMixer").unwrap();
+    let anns = idx.get(mixer);
+    assert_eq!(anns.len(), 2, "audio + hot-path");
+    let names: Vec<TagRef> = anns
+        .iter()
+        .filter_map(|a| match &a.kind {
+            AnnotationKind::Tag(t) => Some(t.clone()),
+            _ => None,
+        })
+        .collect();
+    assert!(names.contains(&TagRef::new("audio")));
+    assert!(names.contains(&TagRef::new("hot-path")));
+    // Source provenance is populated.
+    assert_eq!(anns[0].source_file, "src/lib.rs");
+    assert!(anns[0].source_line > 0);
+
+    let dispatcher = lookup_label(&store, "Dispatcher").unwrap();
+    let dispatch_anns = idx.get(dispatcher);
+    let flow = dispatch_anns
+        .iter()
+        .find_map(|a| match &a.kind {
+            AnnotationKind::Flow {
+                to_qualified,
+                reason,
+            } => Some((to_qualified.clone(), reason.clone())),
+            _ => None,
+        })
+        .expect("flow annotation");
+    assert_eq!(flow.0, "AudioMixer");
+    assert_eq!(flow.1.as_deref(), Some("shared frame buffer"));
+
+    // Rule annotation roundtrips even though we don't validate yet.
+    let inner = lookup_label(&store, "inner").unwrap();
+    let inner_anns = idx.get(inner);
+    let rule = inner_anns
+        .iter()
+        .find_map(|a| match &a.kind {
+            AnnotationKind::Rule { rule_kind, args } => Some((rule_kind.clone(), args.clone())),
+            _ => None,
+        })
+        .expect("rule annotation");
+    assert_eq!(rule.0, "no-import-of");
+    assert_eq!(rule.1, vec!["tag(view)".to_string()]);
+}
+
+#[test]
+fn untagged_node_has_no_annotations_or_tag_edges() {
+    let (store, idx) = build();
+    let untagged = lookup_label(&store, "untagged").unwrap();
+    assert!(idx.get(untagged).is_empty());
+    let outs = store.neighbors(
+        untagged,
+        Direction::Out,
+        Some(&[EdgeKind::Tag, EdgeKind::Flow]),
+    );
+    assert!(outs.is_empty());
+}
+
+#[test]
+fn malformed_tag_does_not_attach() {
+    let (store, idx) = build();
+    let malformed = lookup_label(&store, "malformed").unwrap();
+    // The bad `@yah:tag(invalid space)` doesn't produce an annotation.
+    let tags: Vec<&yah_kg::anno::AnnotationRef> = idx
+        .get(malformed)
+        .iter()
+        .filter(|a| matches!(a.kind, AnnotationKind::Tag(_)))
+        .collect();
+    assert!(
+        tags.is_empty(),
+        "malformed tag should not attach; got {tags:?}"
+    );
+    let outs = store.neighbors(malformed, Direction::Out, Some(&[EdgeKind::Tag]));
+    assert!(outs.is_empty());
+}
+
+#[test]
+fn rerunning_apply_pass_replaces_previous_state() {
+    // Re-applying the pass should be idempotent — same nodes, same edges,
+    // no duplicate AnnotationRefs in the index.
+    let (mut store, mut idx) = build();
+    let before_tag_edges = count_tag_edges(&store);
+    let before_index_len = idx.len();
+
+    apply_pass(&mut store, &mut idx, None);
+    apply_pass(&mut store, &mut idx, None);
+
+    assert_eq!(count_tag_edges(&store), before_tag_edges);
+    assert_eq!(idx.len(), before_index_len);
+}
+
+fn count_tag_edges(store: &Store) -> usize {
+    let mut count = 0;
+    for n in store.all_node_refs() {
+        count += store
+            .neighbors(n.id, Direction::Out, Some(&[EdgeKind::Tag]))
+            .len();
+    }
+    count
+}

--- a/yah-kg-daemon/Cargo.toml
+++ b/yah-kg-daemon/Cargo.toml
@@ -10,6 +10,7 @@ description = "Runtime composition of the yah knowledge-graph: store + watcher +
 [dependencies]
 yah-kg = { path = "../yah-kg" }
 yah-kg-store = { path = "../yah-kg-store" }
+yah-kg-anno = { path = "../yah-kg-anno" }
 notify = "8.2"
 tokio = { version = "1", features = ["sync", "rt", "rt-multi-thread", "macros", "time"] }
 thiserror = "1.0"

--- a/yah-kg-daemon/src/service.rs
+++ b/yah-kg-daemon/src/service.rs
@@ -24,6 +24,7 @@ use yah_kg::rpc::{
     LookupParams, LookupResult, NeighborsParams, NeighborsResult, RootsParams, RootsResult,
     StatsResult, Subgraph, SubgraphParams,
 };
+use yah_kg_anno::{apply_pass, AnnotationIndex};
 use yah_kg_store::{reindex_file, walk_and_index, IndexerRegistry, Store, WalkSummary};
 
 #[derive(Debug, thiserror::Error)]
@@ -66,6 +67,7 @@ struct Booted {
 
 pub struct KgService {
     store: Arc<RwLock<Store>>,
+    annotations: Arc<RwLock<AnnotationIndex>>,
     registry: Arc<IndexerRegistry>,
     events: broadcast::Sender<ArchEvent>,
     booted: Arc<RwLock<Option<Booted>>>,
@@ -82,6 +84,7 @@ impl KgService {
         let (events, _) = broadcast::channel(config.event_capacity);
         Self {
             store: Arc::new(RwLock::new(Store::new())),
+            annotations: Arc::new(RwLock::new(AnnotationIndex::new())),
             registry: Arc::new(registry),
             events,
             booted: Arc::new(RwLock::new(None)),
@@ -115,10 +118,15 @@ impl KgService {
         let start = Instant::now();
         let summary = {
             let mut store = self.store.write().await;
+            let mut anno = self.annotations.write().await;
             // Wipe existing nodes before booting against a new rig.
             *store = Store::new();
-            walk_and_index(&canon, &mut store, &self.registry)
-                .map_err(DaemonError::Index)?
+            *anno = AnnotationIndex::new();
+            let s = walk_and_index(&canon, &mut store, &self.registry)
+                .map_err(DaemonError::Index)?;
+            // Pass 4: annotations.
+            apply_pass(&mut store, &mut anno, None);
+            s
         };
         let elapsed = start.elapsed().as_millis() as u64;
 
@@ -152,6 +160,7 @@ impl KgService {
         }
 
         let store = Arc::clone(&self.store);
+        let annotations = Arc::clone(&self.annotations);
         let registry = Arc::clone(&self.registry);
         let events = self.events.clone();
         let root_for_task = rig_root.clone();
@@ -161,11 +170,12 @@ impl KgService {
             rig_root.clone(),
             move |abs_paths| {
                 let store = Arc::clone(&store);
+                let annotations = Arc::clone(&annotations);
                 let registry = Arc::clone(&registry);
                 let events = events.clone();
                 let root = root_for_task.clone();
                 Box::pin(async move {
-                    apply_paths(abs_paths, &root, &store, &registry, &events).await;
+                    apply_paths(abs_paths, &root, &store, &annotations, &registry, &events).await;
                 })
             },
         )
@@ -210,8 +220,20 @@ impl KgService {
 
         let delta = {
             let mut store = self.store.write().await;
-            reindex_file(&rig_root, &rel, &mut store, &self.registry)
-                .map_err(DaemonError::Index)?
+            let mut anno = self.annotations.write().await;
+            let d = reindex_file(&rig_root, &rel, &mut store, &self.registry)
+                .map_err(DaemonError::Index)?;
+            // Drop annotations for any nodes that vanished.
+            for id in &d.nodes_removed {
+                anno.remove(*id);
+            }
+            // Re-run Pass 4 over the file's surviving + new nodes only.
+            let scope: std::collections::HashSet<_> = store
+                .lookup(&rel, None)
+                .into_iter()
+                .collect();
+            apply_pass(&mut store, &mut anno, Some(&scope));
+            d
         };
 
         emit_delta(&self.events, &delta);
@@ -283,7 +305,12 @@ impl KgService {
 
     pub async fn node(&self, id: NodeId) -> Option<NodeFull> {
         let store = self.store.read().await;
-        store.node_full(id)
+        let mut full = store.node_full(id)?;
+        // Splice in the annotation overlay so a single arch.node call gives
+        // the UI the full picture.
+        let anno = self.annotations.read().await;
+        full.annotations = anno.get(id).to_vec();
+        Some(full)
     }
 
     pub async fn neighbors(&self, params: NeighborsParams) -> NeighborsResult {
@@ -363,6 +390,7 @@ async fn apply_paths(
     abs_paths: Vec<PathBuf>,
     rig_root: &Path,
     store: &Arc<RwLock<Store>>,
+    annotations: &Arc<RwLock<AnnotationIndex>>,
     registry: &Arc<IndexerRegistry>,
     events: &broadcast::Sender<ArchEvent>,
 ) {
@@ -397,8 +425,16 @@ async fn apply_paths(
     let mut totals = (0u32, 0u32, 0u32, 0u32, 0u32);
     for rel in &rels {
         let mut s = store.write().await;
+        let mut a = annotations.write().await;
         match reindex_file(rig_root, rel, &mut s, registry) {
             Ok(delta) => {
+                for id in &delta.nodes_removed {
+                    a.remove(*id);
+                }
+                let scope: std::collections::HashSet<_> =
+                    s.lookup(rel, None).into_iter().collect();
+                apply_pass(&mut s, &mut a, Some(&scope));
+                drop(a);
                 drop(s);
                 totals.0 += delta.nodes_added.len() as u32;
                 totals.1 += delta.nodes_changed.len() as u32;

--- a/yah-kg-daemon/tests/e2e.rs
+++ b/yah-kg-daemon/tests/e2e.rs
@@ -12,9 +12,11 @@ use std::time::Duration;
 use tempfile::TempDir;
 use tokio::sync::broadcast::error::RecvError;
 use tokio::time::timeout;
+use yah_kg::anno::AnnotationKind;
+use yah_kg::edge::EdgeKind;
 use yah_kg::event::{ArchEvent, IndexReason};
 use yah_kg::kind::{CommonKind, Lang, NodeKind};
-use yah_kg::rpc::{LookupParams, RootsParams, SubgraphParams};
+use yah_kg::rpc::{Direction, LookupParams, NeighborsParams, RootsParams, SubgraphParams};
 use yah_kg_daemon::{DaemonError, KgService};
 use yah_kg_rust::RustIndexer;
 use yah_kg_store::IndexerRegistry;
@@ -358,3 +360,192 @@ async fn boot_is_idempotent_and_rebinds_to_new_root() {
     assert!(!from_b.ids.is_empty());
 }
 
+
+#[tokio::test]
+async fn boot_runs_annotation_pass_and_node_returns_annotations() {
+    let dir = tempfile::tempdir().unwrap();
+    write(
+        &dir,
+        "src/lib.rs",
+        r#"//! @yah:tag(layer:core)
+
+/// @yah:tag(audio, hot-path)
+pub struct Mixer;
+
+/// @yah:flow(Mixer, "shared frame buffer")
+pub struct Dispatcher;
+"#,
+    );
+
+    let svc = KgService::new(registry());
+    svc.boot(dir.path().to_path_buf()).await.unwrap();
+
+    // Find the Mixer node and confirm it has typed annotations on NodeFull.
+    let mut mixer = None;
+    for id in svc
+        .lookup(LookupParams {
+            file: "src/lib.rs".into(),
+            line: None,
+            col: None,
+        })
+        .await
+        .ids
+    {
+        if let Some(n) = svc.node(id).await {
+            if n.node.label == "Mixer" {
+                mixer = Some(n);
+                break;
+            }
+        }
+    }
+    let mixer = mixer.expect("Mixer node");
+    let tags: Vec<String> = mixer
+        .annotations
+        .iter()
+        .filter_map(|a| match &a.kind {
+            AnnotationKind::Tag(t) => Some(t.label()),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        tags.contains(&"audio".to_string())
+            && tags.contains(&"hot-path".to_string()),
+        "Mixer annotations should include audio + hot-path; got {tags:?}"
+    );
+
+    // Synthetic Tag node should be reachable via Tag edges from the
+    // structural node.
+    let tag_edges = svc
+        .neighbors(NeighborsParams {
+            id: mixer.node.id,
+            dir: Direction::Out,
+            edges: Some(vec![EdgeKind::Tag]),
+        })
+        .await;
+    let mut tag_labels = Vec::new();
+    for e in &tag_edges.edges {
+        if let Some(n) = svc.node(e.to).await {
+            tag_labels.push(n.node.label);
+        }
+    }
+    assert!(
+        tag_labels.contains(&"audio".to_string()),
+        "tag node `audio` should be reachable; got {tag_labels:?}"
+    );
+
+    // Flow edges resolved within the file: find Dispatcher.
+    let mut dispatcher_node = None;
+    for id in svc
+        .lookup(LookupParams {
+            file: "src/lib.rs".into(),
+            line: None,
+            col: None,
+        })
+        .await
+        .ids
+    {
+        if let Some(n) = svc.node(id).await {
+            if n.node.label == "Dispatcher" {
+                dispatcher_node = Some(n);
+                break;
+            }
+        }
+    }
+    let dispatcher = dispatcher_node.expect("Dispatcher node");
+    let flow_edges = svc
+        .neighbors(NeighborsParams {
+            id: dispatcher.node.id,
+            dir: Direction::Out,
+            edges: Some(vec![EdgeKind::Flow]),
+        })
+        .await;
+    assert_eq!(
+        flow_edges.edges.len(),
+        1,
+        "Dispatcher should have one flow edge"
+    );
+    let flow_target = svc.node(flow_edges.edges[0].to).await.unwrap();
+    assert_eq!(flow_target.node.label, "Mixer");
+}
+
+#[tokio::test]
+async fn reindex_path_refreshes_annotations() {
+    let dir = tempfile::tempdir().unwrap();
+    let lib = write(
+        &dir,
+        "src/lib.rs",
+        "/// @yah:tag(audio)\npub struct Mixer;\n",
+    );
+
+    let svc = KgService::new(registry());
+    svc.boot(dir.path().to_path_buf()).await.unwrap();
+
+    // Sanity: Mixer is tagged audio.
+    let mut mixer_id = None;
+    for id in svc
+        .lookup(LookupParams {
+            file: "src/lib.rs".into(),
+            line: None,
+            col: None,
+        })
+        .await
+        .ids
+    {
+        if let Some(n) = svc.node(id).await {
+            if n.node.label == "Mixer" {
+                mixer_id = Some(id);
+                break;
+            }
+        }
+    }
+    let mixer_id = mixer_id.unwrap();
+    let before = svc.node(mixer_id).await.unwrap();
+    let before_tags: Vec<String> = before
+        .annotations
+        .iter()
+        .filter_map(|a| match &a.kind {
+            AnnotationKind::Tag(t) => Some(t.label()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(before_tags, vec!["audio".to_string()]);
+
+    // Edit the file: change `audio` → `view`.
+    fs::write(&lib, "/// @yah:tag(view)\npub struct Mixer;\n").unwrap();
+    svc.reindex_path(&lib, IndexReason::Manual).await.unwrap();
+
+    let after = svc.node(mixer_id).await.unwrap();
+    let after_tags: Vec<String> = after
+        .annotations
+        .iter()
+        .filter_map(|a| match &a.kind {
+            AnnotationKind::Tag(t) => Some(t.label()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        after_tags,
+        vec!["view".to_string()],
+        "annotation should refresh on reindex; got {after_tags:?}"
+    );
+
+    // Old `audio` tag edge should no longer exist on Mixer.
+    let tag_edges = svc
+        .neighbors(NeighborsParams {
+            id: mixer_id,
+            dir: Direction::Out,
+            edges: Some(vec![EdgeKind::Tag]),
+        })
+        .await;
+    let mut labels = Vec::new();
+    for e in &tag_edges.edges {
+        if let Some(n) = svc.node(e.to).await {
+            labels.push(n.node.label);
+        }
+    }
+    assert_eq!(
+        labels,
+        vec!["view".to_string()],
+        "old audio tag edge should be gone"
+    );
+}

--- a/yah-kg-store/src/store.rs
+++ b/yah-kg-store/src/store.rs
@@ -153,6 +153,13 @@ impl Store {
         self.nodes.get(&id)
     }
 
+    /// Iterator over every node currently in the store. Order is
+    /// unspecified (HashMap iteration order). Used by the annotation
+    /// applier to find which nodes have docs to scan.
+    pub fn all_node_refs(&self) -> impl Iterator<Item = &NodeRef> {
+        self.nodes.values()
+    }
+
     pub fn node_full(&self, id: NodeId) -> Option<NodeFull> {
         let node = self.nodes.get(&id)?.clone();
         Some(NodeFull {

--- a/yah-kg/src/anno.rs
+++ b/yah-kg/src/anno.rs
@@ -1,0 +1,129 @@
+//! @arch:layer(kg)
+//! @arch:role(schema)
+//!
+//! Annotation overlay types.
+//!
+//! Annotations are human-authored decorations on structural KG nodes. They
+//! live in source as `@yah:` directives inside doc comments. Three kinds:
+//!
+//! * **Tag** — set membership. `@yah:tag(audio, hot-path)` adds the
+//!   annotated node to the named taxonomies. Stored as `EdgeKind::Tag`
+//!   edges from the structural node to a synthetic `Tag` node so the
+//!   "show me everything in `audio`" query is a 1-hop subgraph fetch.
+//! * **Flow** — curated edge. `@yah:flow(audio::mixer → dispatch::loop,
+//!   "shared frame buffer")` declares a meaningful coupling that
+//!   `Calls`/`Imports` can't see. Endpoints resolve via qualified-name
+//!   lookup; rotted endpoints surface as warnings, not silent drops.
+//! * **Rule** — graph constraint. `@yah:rule(no-import-of: tag(view))`
+//!   declares an invariant the validator checks. Rule semantics are
+//!   reserved in the contract; the v1 extractor parses them but doesn't
+//!   yet ship a validator.
+
+use crate::ids::NodeId;
+use serde::{Deserialize, Serialize};
+
+/// One annotation as observed on a node, with provenance back to its
+/// source-line so authors can be pointed at the offending comment.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AnnotationRef {
+    /// What was annotated.
+    pub anchor: NodeId,
+    /// Where the annotation lived in source. Both fields are convenience
+    /// for tooling — the structural file is also in `anchor`'s NodeRef.
+    pub source_file: String,
+    pub source_line: u32,
+    /// The annotation payload.
+    pub kind: AnnotationKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "anno", rename_all = "snake_case")]
+pub enum AnnotationKind {
+    /// `@yah:tag(name)` or `@yah:tag(ns:name)`.
+    Tag(TagRef),
+    /// `@yah:flow(<from> → <to>, "<reason>")`. `to_qualified` is the raw
+    /// qualified-name string from source; the daemon resolves it against
+    /// the structural index when emitting the `Flow` edge.
+    Flow {
+        to_qualified: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        reason: Option<String>,
+    },
+    /// `@yah:rule(<rule-kind>: <args>)`. Reserved — v1 extractors parse
+    /// these into the structure but no validator runs against them yet.
+    Rule {
+        rule_kind: String,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        args: Vec<String>,
+    },
+}
+
+/// A tag with optional namespace. `layer:core` parses to `TagRef { ns:
+/// Some("layer"), name: "core" }`. `audio` parses to `TagRef { ns: None,
+/// name: "audio" }`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct TagRef {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub namespace: Option<String>,
+    pub name: String,
+}
+
+impl TagRef {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            namespace: None,
+            name: name.into(),
+        }
+    }
+
+    pub fn namespaced(namespace: impl Into<String>, name: impl Into<String>) -> Self {
+        Self {
+            namespace: Some(namespace.into()),
+            name: name.into(),
+        }
+    }
+
+    /// Stable canonical string. Always prefixed `tag:` so synthetic Tag
+    /// node ids never collide with structural-node qualified names.
+    pub fn qualified(&self) -> String {
+        match &self.namespace {
+            Some(ns) => format!("tag:{}:{}", ns, self.name),
+            None => format!("tag:{}", self.name),
+        }
+    }
+
+    /// Display label — the leaf name, or `ns:name` for namespaced tags.
+    pub fn label(&self) -> String {
+        match &self.namespace {
+            Some(ns) => format!("{}:{}", ns, self.name),
+            None => self.name.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tag_ref_qualified_distinguishes_namespace() {
+        assert_eq!(TagRef::new("audio").qualified(), "tag:audio");
+        assert_eq!(
+            TagRef::namespaced("layer", "core").qualified(),
+            "tag:layer:core"
+        );
+    }
+
+    #[test]
+    fn tag_ref_label_is_human_readable() {
+        assert_eq!(TagRef::new("audio").label(), "audio");
+        assert_eq!(TagRef::namespaced("layer", "core").label(), "layer:core");
+    }
+
+    #[test]
+    fn annotation_kind_serializes_with_tag_field() {
+        let a = AnnotationKind::Tag(TagRef::new("audio"));
+        let json = serde_json::to_string(&a).unwrap();
+        assert!(json.contains("\"anno\":\"tag\""), "got {json}");
+    }
+}

--- a/yah-kg/src/edge.rs
+++ b/yah-kg/src/edge.rs
@@ -88,6 +88,16 @@ pub enum EdgeKind {
     /// Document → schema it conforms to.
     ConformsTo,
 
+    // ---------- Annotation overlay ----------
+    /// Structural node → synthetic `Tag` node. Powers the `@yah:tag(...)`
+    /// taxonomy: layer membership, role assignment, aspect grouping.
+    Tag,
+    /// Curated relation between two structural nodes that the AST can't
+    /// derive. `@yah:flow(audio::mixer → dispatch::loop)` is the canonical
+    /// example — declares a meaningful coupling (shared state, planned
+    /// future call, observed runtime path) the human knows about.
+    Flow,
+
     // ---------- Koda extension slot ----------
     Koda(KodaEdge),
 }

--- a/yah-kg/src/ids.rs
+++ b/yah-kg/src/ids.rs
@@ -8,6 +8,7 @@
 //! name, file) triple is unchanged. A rename invalidates the id, which is
 //! the correct behaviour: a rename is a remove+add at the graph level.
 
+use crate::anno::AnnotationRef;
 use crate::kind::{Lang, NodeKind};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::BTreeMap;
@@ -163,9 +164,11 @@ pub struct NodeFull {
     /// Free-form per-kind metadata.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub properties: BTreeMap<String, String>,
-    /// Annotation overlay references (resolved by `rs-hack-arch`).
+    /// Annotation overlay attached to this node by `yah-kg-anno`. Each
+    /// `AnnotationRef` is anchored back at the source line it came from
+    /// so tooling can point authors at the offending comment.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub annotations: Vec<String>,
+    pub annotations: Vec<AnnotationRef>,
 }
 
 #[cfg(test)]

--- a/yah-kg/src/kind.rs
+++ b/yah-kg/src/kind.rs
@@ -72,6 +72,12 @@ pub enum CommonKind {
     /// Whole-file entity (used by JSON/YAML/Koda where the file IS
     /// the addressable unit).
     Document,
+    /// Synthetic taxonomy node created by the annotation overlay
+    /// (`@yah:tag(...)`). Tag nodes have `synthetic = true`, a fixed
+    /// `file = "<tag>"` sentinel, and a stable id derived from the tag's
+    /// qualified name (e.g. `tag:layer:core`). They participate in the
+    /// graph through `EdgeKind::Tag` edges.
+    Tag,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/yah-kg/src/lib.rs
+++ b/yah-kg/src/lib.rs
@@ -14,6 +14,7 @@
 //! depend on a stable type surface without dragging in `petgraph`, `syn`,
 //! `tree-sitter`, or transport machinery.
 
+pub mod anno;
 pub mod edge;
 pub mod event;
 pub mod ids;
@@ -21,6 +22,7 @@ pub mod indexer;
 pub mod kind;
 pub mod rpc;
 
+pub use anno::{AnnotationKind, AnnotationRef, TagRef};
 pub use edge::{EdgeId, EdgeKind, EdgeOut, KodaEdge};
 pub use event::{ArchEvent, ChangedField, IndexReason, IndexScope};
 pub use ids::{NodeFull, NodeId, NodeRef, Span};


### PR DESCRIPTION
Replaces rs-hack-arch's parallel annotation graph with a node-anchored overlay sitting on top of the structural KG. Three orthogonal annotation kinds, each anchored to a structural node by NodeId so renames follow and deletions surface loudly.

Contract additions in yah-kg:
* `EdgeKind::Tag` — structural node → synthetic Tag node (set membership). Powers "show me everything in `audio`" as a 1-hop subgraph fetch.
* `EdgeKind::Flow` — node → node curated relationship the AST can't derive (shared mutable state, planned future call, observed runtime coupling).
* `CommonKind::Tag` — synthetic taxonomy node. Stable id derived from `tag:<ns>:<name>` qualified, file = `<tag>` sentinel, synthetic = true.
* `anno` module: `AnnotationRef`, `AnnotationKind` (Tag / Flow / Rule), `TagRef` with optional namespace.
* `NodeFull.annotations` is now `Vec<AnnotationRef>` (was an unused `Vec<String>` placeholder).

New yah-kg-anno crate:
* `parser`: scans doc strings for `@yah:tag(...)`, `@yah:flow(...)`, `@yah:rule(...)`. Paren-depth-aware payload splitting (so `cycle(a, b, c)` is one rule arg, not three). Unicode `→` and ASCII `->` both work as flow arrows. Optional reason string after a comma. Malformed directives surface as ParseError without aborting the rest of the scan.
* `index`: `AnnotationIndex` side map from NodeId to its `Vec<AnnotationRef>`. Atomic per-node replace semantics.
* `apply`: Pass 4 driver. For each node with a doc, parse → for each Tag, ensure synthetic Tag node exists + emit Tag edge; for each Flow, resolve target via exact qualified-name match (suffix-match fallback when unique) and emit Flow edge; for Rule, populate the index but no validator yet. Wipes prior Tag/Flow edges per-node so reruns are idempotent.

yah-kg-daemon integration:
* `KgService` now holds `Arc<RwLock<AnnotationIndex>>` alongside the store.
* `boot` runs Pass 4 over every node after `walk_and_index`.
* `reindex_path` and the watcher path scope Pass 4 to just the reindexed file's nodes via `apply_pass(..., Some(&scope))`, re-applying after structural diff to refresh tags/flows.
* `node()` query splices `AnnotationIndex.get(id)` into the returned `NodeFull.annotations` so `arch.node` gives the UI the full overlay in one round-trip.

Tests:
* yah-kg: 3 unit tests for TagRef qualified/label/serde shape.
* yah-kg-anno parser: 11 unit tests covering single tag, multi-tag, arrow forms, implicit-from flow, balanced parens in rule args, unknown directive, prose-with-directive, invalid tag chars.
* yah-kg-anno e2e: 7 tests against fixture Rust source — synthetic Tag nodes + edges, file-level `//!` annotations attaching to the File node, flow resolution within file, AnnotationIndex provenance, untagged-node-clean, malformed-tag rejected, applier idempotency.
* yah-kg-daemon e2e: 2 new tests bringing the suite to 9 — boot populates the annotation pass and `node()` returns typed AnnotationRefs; reindex on edited file refreshes the overlay (audio → view tag swap, old edge gone).

Supporting yah-kg-store change:
* New `Store::all_node_refs()` iterator over every node, used by the applier to find which nodes need scanning and by the flow resolver to look up qualified names.

Naive layer/role precursor in `[workspace.metadata.arch.layers]` is preserved for now since rs-hack-arch still references it; once the old crate is removed the workspace metadata can be cut down to just the legal tag namespaces.